### PR TITLE
Add activation time metrics

### DIFF
--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -66,6 +66,7 @@ DEFAULT_FILTER_ATTRS = [
     "RequestCpus",
     "RequestMemory",
     "RecordTime",
+    "JobStartDate",
     "JobCurrentStartDate",
     "MemoryUsage",
     "NumJobStarts",

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -402,7 +402,7 @@ class OsgScheddCpuFilter(BaseFilter):
                 continue
             if ((start_date > act_cutoff_date) and
                 (activation_duration < (act_cutoff_date - 24*3600) and
-                (setup_duration < (act_cutoff_date - 24*3600))):
+                (setup_duration < (act_cutoff_date - 24*3600)))):
                 activation_durations.append(activation_duration)
                 setup_durations.append(setup_duration)
 

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -82,7 +82,7 @@ DEFAULT_FILTER_ATTRS = [
     "TransferOutputFilesTotalCount",
     "SingularityImage",
     "ActivationDuration",
-    "ActivationSetUpDuration",
+    "ActivationSetupDuration",
 ]
 
 
@@ -394,11 +394,13 @@ class OsgScheddCpuFilter(BaseFilter):
         activation_durations = []
         setup_durations = []
         act_cutoff_date = 1_640_100_600  # 2021-12-21 09:30:00
-        for (start_date, activation_duration, setup_duration) in zip(
+        for (start_date, current_start_date, activation_duration, setup_duration) in zip(
+                data["JobStartDate"],
                 data["JobCurrentStartDate"],
                 data["ActivationDuration"],
-                data["ActivationSetUpDuration"]):
-            if None in {activation_duration, setup_duration}:
+                data["ActivationSetupDuration"]):
+            start_date = current_start_date or start_date
+            if None in [start_date, activation_duration, setup_duration]:
                 continue
             if ((start_date > act_cutoff_date) and
                 (activation_duration < (act_cutoff_date - 24*3600) and
@@ -553,11 +555,13 @@ class OsgScheddCpuFilter(BaseFilter):
         activation_durations = []
         setup_durations = []
         act_cutoff_date = 1_640_100_600  # 2021-12-21 09:30:00
-        for (start_date, activation_duration, setup_duration) in zip(
+        for (start_date, current_start_date, activation_duration, setup_duration) in zip(
+                data["JobStartDate"],
                 data["JobCurrentStartDate"],
                 data["ActivationDuration"],
-                data["ActivationSetUpDuration"]):
-            if None in {activation_duration, setup_duration}:
+                data["ActivationSetupDuration"]):
+            start_date = current_start_date or start_date
+            if None in [start_date, activation_duration, setup_duration]:
                 continue
             if ((start_date > act_cutoff_date) and
                 (activation_duration < (act_cutoff_date - 24*3600) and

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -425,14 +425,12 @@ class OsgScheddCpuFilter(BaseFilter):
             row["% Jobs using S'ty"] = 0
 
         # Compute activation time stats
+        row["Mean Actv Hrs"] = ""
+        row["Mean Setup Secs"] = ""
         if len(activation_durations) > 0:
             row["Mean Actv Hrs"] = (sum(activation_durations) / len(activation_durations)) / 3600
-        else:
-            row["Mean Actv Hrs"] = ""
         if len(setup_durations) > 0:
             row["Mean Setup Secs"] = sum(setup_durations) / len(setup_durations)
-        else:
-            row["Mean Setup Secs"] = ""
 
         # Compute time percentiles and stats
         if len(long_times_sorted) > 0:
@@ -550,6 +548,23 @@ class OsgScheddCpuFilter(BaseFilter):
             else:
                 num_exec_attempts_with_file_counts.append(None)
 
+        # Activation metrics added in 9.4.1
+        # Added to the OSG Connect access points at 1640100600
+        activation_durations = []
+        setup_durations = []
+        act_cutoff_date = 1_640_100_600  # 2021-12-21 09:30:00
+        for (start_date, activation_duration, setup_duration) in zip(
+                data["JobCurrentStartDate"],
+                data["ActivationDuration"],
+                data["ActivationSetUpDuration"]):
+            if None in {activation_duration, setup_duration}:
+                continue
+            if ((start_date > act_cutoff_date) and
+                (activation_duration < (act_cutoff_date - 24*3600) and
+                (setup_duration < (act_cutoff_date - 24*3600)))):
+                activation_durations.append(activation_duration)
+                setup_durations.append(setup_duration)
+
         # Compute columns
         row["All CPU Hours"]    = sum(self.clean(total_cpu_time)) / 3600
         row["Good CPU Hours"]   = sum(self.clean(goodput_cpu_time)) / 3600
@@ -630,6 +645,14 @@ class OsgScheddCpuFilter(BaseFilter):
             row["Input MB / File"] = -999
             row["Output Files Xferd / Exec Att"] = -999
             row["Output MB / File"] = -999
+
+        # Compute activation time stats
+        row["Mean Actv Hrs"] = ""
+        row["Mean Setup Secs"] = ""
+        if len(activation_durations) > 0:
+            row["Mean Actv Hrs"] = (sum(activation_durations) / len(activation_durations)) / 3600
+        if len(setup_durations) > 0:
+            row["Mean Setup Secs"] = sum(setup_durations) / len(setup_durations)
 
         # Compute time percentiles and stats
         if len(long_times_sorted) > 0:

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -70,6 +70,7 @@ class OsgScheddCpuFormatter(BaseFormatter):
             "Max Hrs":    lambda x: f"<td>{hhmm(x)}</td>",
             "Mean Hrs":   lambda x: f"<td>{hhmm(x)}</td>",
             "Std Hrs":    lambda x: f"<td>{hhmm(x)}</td>",
+            "Mean Actv Hrs": lambda x: f"<td>{hhmm(x)}</td>",
             "CPU Hours / Bad Exec Att": lambda x: f"<td>{float(x):.1f}</td>",
             "Shadw Starts / Job Id":    lambda x: f"<td>{float(x):.2f}</td>",
             "Exec Atts / Shadw Start":  lambda x: f"<td>{float(x):.3f}</td>",
@@ -106,6 +107,9 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["Shadw Starts / Job Id"]   = "Num Shadw Starts per Num Uniq Job Ids"
         custom_items["Exec Atts / Shadw Start"] = "Num Exec Atts per Num Shadw Starts"
         custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
+
+        custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
+        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds)"
 
         custom_items["Min/25%/Median/75%/Max/Mean/Std Hrs"] = "Final execution wallclock hours that a non-short job (Min-Max) or jobs (Mean/Std) ran for (excluding Short jobs, excluding Local and Scheduler Universe jobs)"
 


### PR DESCRIPTION
Can only add two -- `ActivationDuration` and `ActivationSetupDuration` -- for now until HTCONDOR-908 and related issues (`condor_starter` version) are solved.