### PR TITLE
OPS-262 Email reports use new collectors

### DIFF
--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -8,7 +8,7 @@ import elasticsearch.helpers
 
 class BaseFilter:
     name = "job history"
-    
+
     def __init__(self, skip_init=False, **kwargs):
         if skip_init:
             return
@@ -117,19 +117,19 @@ class BaseFilter:
             self.user_filter,
         ]
         return filters
-    
+
     def scan_and_filter(self, es_index, start_ts, end_ts, **kwargs):
         # Returns a 3-level dictionary that contains data gathered from
         # Elasticsearch and filtered through whatever methods have been
         # defined in self.get_filters()
-        
+
         # Create a data structure for storing filtered data:
         # 3-level defaultdict -> list
         # First level - Aggregation level (e.g. Schedd, User, Project)
         # Second level - Aggregation name (e.g. value of ScheddName, UserName, ProjectName)
         # Third level - Field name to be aggregated (e.g. RemoteWallClockTime, RequestCpus)
         filtered_data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-        
+
         query = self.get_query(
             index=es_index,
             start_ts=start_ts,
@@ -199,7 +199,7 @@ class BaseFilter:
 
         # Output dictionary
         row = {}
-        
+
         # Compute goodput and total CPU hours columns
         goodput_cpu_time = []
         total_cpu_time = []
@@ -225,12 +225,12 @@ class BaseFilter:
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Max MB Sent"]      = max(self.clean(data["BytesSent"], allow_empty_list=False)) / 1e6
         row["Max MB Recv"]      = max(self.clean(data["BytesRecvd"], allow_empty_list=False)) / 1e6
-        
+
         if row["All CPU Hours"] > 0:
             row["% Good CPU Hours"] = 100 * row["Good CPU Hours"] / row["All CPU Hours"]
         else:
             row["% Good CPU Hours"] = 0
-        
+
         return row
 
     def merge_filtered_data(self, data, agg):

--- a/accounting/filters/ChtcScheddCpuFilter.py
+++ b/accounting/filters/ChtcScheddCpuFilter.py
@@ -13,7 +13,7 @@ DEFAULT_COLUMNS = {
     50: "% Rm'd Jobs",
     60: "% Short Jobs",
     70: "% Jobs w/>1 Exec Att",
-    
+
     80: "Shadw Starts / Job Id",
     90: "Exec Atts / Shadw Start",
 
@@ -70,7 +70,7 @@ DEFAULT_FILTER_ATTRS = [
 
 class ChtcScheddCpuFilter(BaseFilter):
     name = "CHTC schedd job history"
-    
+
     def schedd_filter(self, data, doc):
 
         # Get input dict
@@ -146,7 +146,7 @@ class ChtcScheddCpuFilter(BaseFilter):
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
-        
+
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
@@ -248,7 +248,7 @@ class ChtcScheddCpuFilter(BaseFilter):
         for attr in filter_attrs:
             o[attr].append(i.get(attr, None))
 
-    
+
     def site_filter(self, data, doc):
 
         # Get input dict
@@ -303,7 +303,7 @@ class ChtcScheddCpuFilter(BaseFilter):
             rm_columns = [30,45,50,70,80,90,300,305,310,320,330,340,350,370,380,390]
             [columns.pop(key) for key in rm_columns]
         return columns
-            
+
     def merge_filtered_data(self, data, agg):
         rows = super().merge_filtered_data(data, agg)
         if agg == "Site":
@@ -367,7 +367,7 @@ class ChtcScheddCpuFilter(BaseFilter):
         row["Max Used Mem MB"]  = max(self.clean(data["MemoryUsage"], allow_empty_list=False))
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Users"] = len(set(data["User"]))
-   
+
         if row["Num Uniq Job Ids"] > 0:
             row["% Short Jobs"] = 100 * row["Num Short Jobs"] / row["Num Uniq Job Ids"]
         else:
@@ -540,6 +540,6 @@ class ChtcScheddCpuFilter(BaseFilter):
             else:
                 row["Most Used Schedd"] = "UNKNOWN"
         if agg == "Projects":
-            row["Num Users"] = len(set(data["User"]))  
+            row["Num Users"] = len(set(data["User"]))
 
-        return row 
+        return row

--- a/accounting/filters/ChtcScheddCpuRemovedFilter.py
+++ b/accounting/filters/ChtcScheddCpuRemovedFilter.py
@@ -52,7 +52,7 @@ DEFAULT_FILTER_ATTRS = [
 
 class ChtcScheddCpuRemovedFilter(BaseFilter):
     name = "CHTC schedd removed job history"
-    
+
     def schedd_filter(self, data, doc):
 
         # Get input dict
@@ -61,7 +61,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
-       
+
         # Filter out jobs that were not removed
         if i.get("JobStatus", 4) != 3:
             return
@@ -113,11 +113,11 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
         o = data["Users"][user]
-        
+
         # Filter out jobs that were not removed
         if i.get("JobStatus", 4) != 3:
             return
-         
+
         # Add custom attrs to the list of attrs
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
         filter_attrs = filter_attrs + ["ScheddName"]
@@ -127,7 +127,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
-        
+
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
@@ -170,11 +170,11 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this project
         project = i.get("ProjectName", "UNKNOWN") or "UNKNOWN"
         o = data["Projects"][project]
-    
+
         # Filter out jobs that were not removed
         if i.get("JobStatus",4) != 3:
             return
-        
+
         # Filter out jobs that did not run in the OS pool
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
@@ -183,7 +183,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         # Add custom attrs to the list of attrs
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
         filter_attrs = filter_attrs + ["User"]
-        
+
         # Count number of DAGNode Jobs
         if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
             o["_NumDAGNodes"].append(1)
@@ -236,7 +236,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         if agg == "Projects":
             columns[5] = "Num Users"
         return columns
-            
+
     def compute_custom_columns(self, data, agg, agg_name):
         # Output dictionary
         row = {}
@@ -311,7 +311,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         row["Max MB Sent"]      = max(self.clean(data["BytesSent"], allow_empty_list=False)) / 1e6
         row["Avg MB Recv"]      = stats.mean(self.clean(data["BytesRecvd"], allow_empty_list=False)) / 1e6
         row["Max MB Recv"]      = max(self.clean(data["BytesRecvd"], allow_empty_list=False)) / 1e6
-        
+
         row["Num DAG Node Jobs"] = sum(data["_NumDAGNodes"])
         row["Max Rqst Mem MB"]  = max(self.clean(data['RequestMemory'], allow_empty_list=False))
         row["Med Used Mem MB"]  = stats.median(self.clean(data["MemoryUsage"], allow_empty_list=False))

--- a/accounting/filters/ChtcScheddGpuFilter.py
+++ b/accounting/filters/ChtcScheddGpuFilter.py
@@ -15,7 +15,7 @@ DEFAULT_COLUMNS = {
     50: "% Rm'd Jobs",
     60: "% Short Jobs",
     70: "% Jobs w/>1 Exec Att",
-    
+
     80: "Shadw Starts / Job Id",
     90: "Exec Atts / Shadw Start",
 
@@ -104,7 +104,7 @@ class ChtcScheddGpuFilter(BaseFilter):
             }
         }
         return query
-    
+
     def schedd_filter(self, data, doc):
 
         # Get input dict
@@ -178,7 +178,7 @@ class ChtcScheddGpuFilter(BaseFilter):
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
-        
+
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
@@ -276,7 +276,7 @@ class ChtcScheddGpuFilter(BaseFilter):
         for attr in filter_attrs:
             o[attr].append(i.get(attr, None))
 
-    
+
     def site_filter(self, data, doc):
 
         # Get input dict
@@ -327,7 +327,7 @@ class ChtcScheddGpuFilter(BaseFilter):
             rm_columns = [30,35,45,50,70,80,90,180,181,190,191,300,303,305,307,310,320,330,340,350,390]
             [columns.pop(key) for key in rm_columns]
         return columns
-            
+
     def merge_filtered_data(self, data, agg):
         rows = super().merge_filtered_data(data, agg)
         if agg == "Site":
@@ -496,9 +496,9 @@ class ChtcScheddGpuFilter(BaseFilter):
             else:
                 row["Most Used Schedd"] = "UNKNOWN"
         if agg == "Projects":
-            row["Num Users"] = len(set(data["User"]))  
+            row["Num Users"] = len(set(data["User"]))
 
-        return row 
+        return row
 
 
     def compute_site_custom_columns(self, data, agg, agg_name):

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -1,5 +1,6 @@
 import logging
 import htcondor
+import pickle
 import statistics as stats
 from pathlib import Path
 from .BaseFilter import BaseFilter
@@ -91,38 +92,67 @@ class OsgScheddCpuFilter(BaseFilter):
     name = "OSG schedd job history"
 
     def __init__(self, **kwargs):
-        self.collector_host = "flock.opensciencegrid.org"
+        self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}
+        self.schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
         self.schedd_collector_host_map = {}
+        if self.schedd_collector_host_map_pickle.exists():
+            try:
+                self.schedd_collector_host_map = pickle.load(open(self.schedd_collector_host_map_pickle, "rb"))
+            except IOError:
+                pass
         super().__init__(**kwargs)
 
     def schedd_collector_host(self, schedd):
         # Query Schedd ad in Collector for its CollectorHost,
         # unless result previously cached
         if schedd not in self.schedd_collector_host_map:
+            self.schedd_collector_host_map[schedd] = set()
 
-            collector = htcondor.Collector(self.collector_host)
-            ads = collector.query(
-                htcondor.AdTypes.Schedd,
-                constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
-                projection=["CollectorHost"],
-            )
-            ads = list(ads)
-            if len(ads) == 0:
-                logging.warning(f'Could not find Schedd ClassAd for Machine == "{schedd}"')
-                logging.warning(f"Assuming jobs from {schedd} are not in OS pool")
-                self.schedd_collector_host_map[schedd] = "UNKNOWN"
-                return "UNKNOWN"
-            if len(ads) > 1:
-                logging.warning(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
+            for collector_host in self.collector_hosts:
+                collector = htcondor.Collector(collector_host)
+                ads = collector.query(
+                    htcondor.AdTypes.Schedd,
+                    constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
+                    projection=["CollectorHost"],
+                )
+                ads = list(ads)
+                if len(ads) == 0:
+                    continue
+                if len(ads) > 1:
+                    logging.warning(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
 
-            # Cache the CollectorHost in the map
-            if "CollectorHost" in ads[0]:
-                self.schedd_collector_host_map[schedd] = ads[0]["CollectorHost"].split(':')[0]
+                # Cache the CollectorHost in the map
+                if "CollectorHost" in ads[0]:
+                    collector_hosts = set()
+                    for collector_host in ads[0]["CollectorHost"].split(","):
+                        collector_hosts.add(collector_host.strip().split(":")[0])
+                    if collector_hosts:
+                        self.schedd_collector_host_map[schedd] = collector_hosts
+                        break
             else:
-                logging.warning(f"CollectorHost not found in Schedd ClassAd for {schedd}")
-                self.schedd_collector_host_map[schedd] = "UNKNOWN"
+                logging.warning(f"Did not find Machine == {schedd} in collectors")
+
+            # Update the pickle
+            if len(self.schedd_collector_host_map[schedd]) > 0:
+                # Don't store any unknown schedds
+                fixed_host_map = self.schedd_collector_host_map.copy()
+                for k, v in fixed_host_map.items():
+                    if len(v) == 0:
+                        del fixed_host_map[k]
+                with open(self.schedd_collector_host_map_pickle, "wb") as f:
+                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
+
+    def is_ospool_job(self, ad):
+        remote_pool = set()
+        if "LastRemotePool" in ad and ad["LastRemotePool"]:
+            remote_pool.add(ad["LastRemotePool"])
+        else:
+            schedd = ad.get("ScheddName", "UNKNOWN") or "UNKNOWN"
+            if schedd != "UNKNOWN":
+                remote_pool = self.schedd_collector_host(schedd)
+        return bool(remote_pool & self.collector_hosts)
 
     def schedd_filter(self, data, doc):
 
@@ -134,7 +164,7 @@ class OsgScheddCpuFilter(BaseFilter):
         o = data["Schedds"][schedd]
 
         # Filter out jobs that did not run in the OS pool
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        if not self.is_ospool_job(i):
             return
 
         # Get list of attrs
@@ -182,8 +212,7 @@ class OsgScheddCpuFilter(BaseFilter):
         o = data["Users"][user]
 
         # Filter out jobs that did not run in the OS pool
-        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        if not self.is_ospool_job(i):
             return
 
         # Add custom attrs to the list of attrs
@@ -236,8 +265,7 @@ class OsgScheddCpuFilter(BaseFilter):
         o = data["Projects"][project]
 
         # Filter out jobs that did not run in the OS pool
-        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        if not self.is_ospool_job(i):
             return
 
         # Add custom attrs to the list of attrs
@@ -282,6 +310,10 @@ class OsgScheddCpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Filter out jobs that did not run in the OS pool
+        if not self.is_ospool_job(i):
+            return
+
         # Filter out jobs that were removed
         if i.get("JobStatus", 4) == 3:
             return
@@ -293,11 +325,6 @@ class OsgScheddCpuFilter(BaseFilter):
         # Get output dict for this site
         site = i.get("MachineAttrGLIDEIN_ResourceName0", "UNKNOWN") or "UNKNOWN"
         o = data["Site"][site]
-
-        # Filter out jobs that did not run in the OS pool
-        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
-            return
 
         # Add custom attrs to the list of attrs
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -1,5 +1,6 @@
 import logging
 import htcondor
+import pickle
 import statistics as stats
 from pathlib import Path
 from .BaseFilter import BaseFilter
@@ -57,40 +58,69 @@ DEFAULT_FILTER_ATTRS = [
 
 class OsgScheddCpuRemovedFilter(BaseFilter):
     name = "OSG schedd removed job history"
-    
+
     def __init__(self, **kwargs):
-        self.collector_host = "flock.opensciencegrid.org"
+        self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}
+        self.schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
         self.schedd_collector_host_map = {}
+        if self.schedd_collector_host_map_pickle.exists():
+            try:
+                self.schedd_collector_host_map = pickle.load(open(self.schedd_collector_host_map_pickle, "rb"))
+            except IOError:
+                pass
         super().__init__(**kwargs)
 
     def schedd_collector_host(self, schedd):
         # Query Schedd ad in Collector for its CollectorHost,
         # unless result previously cached
         if schedd not in self.schedd_collector_host_map:
+            self.schedd_collector_host_map[schedd] = set()
 
-            collector = htcondor.Collector(self.collector_host)
-            ads = collector.query(
-                htcondor.AdTypes.Schedd,
-                constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
-                projection=["CollectorHost"],
-            )
-            ads = list(ads)
-            if len(ads) == 0:
-                logging.warning(f'Could not find Schedd ClassAd for Machine == "{schedd}"')
-                logging.warning(f"Assuming jobs from {schedd} are not in OS pool")
-                self.schedd_collector_host_map[schedd] = "UNKNOWN"
-                return "UNKNOWN"
-            if len(ads) > 1:
-                logging.warning(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
+            for collector_host in self.collector_hosts:
+                collector = htcondor.Collector(collector_host)
+                ads = collector.query(
+                    htcondor.AdTypes.Schedd,
+                    constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
+                    projection=["CollectorHost"],
+                )
+                ads = list(ads)
+                if len(ads) == 0:
+                    continue
+                if len(ads) > 1:
+                    logging.warning(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
 
-            # Cache the CollectorHost in the map
-            if "CollectorHost" in ads[0]:
-                self.schedd_collector_host_map[schedd] = ads[0]["CollectorHost"].split(':')[0]
+                # Cache the CollectorHost in the map
+                if "CollectorHost" in ads[0]:
+                    collector_hosts = set()
+                    for collector_host in ads[0]["CollectorHost"].split(","):
+                        collector_hosts.add(collector_host.strip().split(":")[0])
+                    if collector_hosts:
+                        self.schedd_collector_host_map[schedd] = collector_hosts
+                        break
             else:
-                logging.warning(f"CollectorHost not found in Schedd ClassAd for {schedd}")
-                self.schedd_collector_host_map[schedd] = "UNKNOWN"
+                logging.warning(f"Did not find Machine == {schedd} in collectors")
+
+            # Update the pickle
+            if len(self.schedd_collector_host_map[schedd]) > 0:
+                # Don't store any unknown schedds
+                fixed_host_map = self.schedd_collector_host_map.copy()
+                for k, v in fixed_host_map.items():
+                    if len(v) == 0:
+                        del fixed_host_map[k]
+                with open(self.schedd_collector_host_map_pickle, "wb") as f:
+                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
+
+    def is_ospool_job(self, ad):
+        remote_pool = set()
+        if "LastRemotePool" in ad and ad["LastRemotePool"]:
+            remote_pool.add(ad["LastRemotePool"])
+        else:
+            schedd = ad.get("ScheddName", "UNKNOWN") or "UNKNOWN"
+            if schedd != "UNKNOWN":
+                remote_pool = self.schedd_collector_host(schedd)
+        return bool(remote_pool & self.collector_hosts)
 
     def schedd_filter(self, data, doc):
 
@@ -100,13 +130,13 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
-       
+
         # Filter out jobs that were not removed
         if i.get("JobStatus",4) != 3:
             return
 
-        # Filter out jobs that did not run in the OS pool        
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        # Filter out jobs that did not run in the OS pool
+        if not self.is_ospool_job(i):
             return
 
         # Get list of attrs
@@ -156,14 +186,13 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
         o = data["Users"][user]
-        
+
         # Filter out jobs that were not removed
         if i.get("JobStatus",4) != 3:
             return
-         
+
         # Filter out jobs that did not run in the OS pool
-        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        if not self.is_ospool_job(i):
             return
 
         # Add custom attrs to the list of attrs
@@ -175,7 +204,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
-        
+
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
@@ -218,20 +247,19 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Get output dict for this project
         project = i.get("ProjectName", "UNKNOWN") or "UNKNOWN"
         o = data["Projects"][project]
-    
+
         # Filter out jobs that were not removed
         if i.get("JobStatus",4) != 3:
             return
-        
+
         # Filter out jobs that did not run in the OS pool
-        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
-        if i.get("LastRemotePool", self.schedd_collector_host(schedd)) != self.collector_host:
+        if not self.is_ospool_job(i):
             return
 
         # Add custom attrs to the list of attrs
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
         filter_attrs = filter_attrs + ["User"]
-        
+
         # Count number of DAGNode Jobs
         if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
             o["_NumDAGNodes"].append(1)
@@ -286,7 +314,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         if agg == "Projects":
             columns[5] = "Num Users"
         return columns
-            
+
     def compute_custom_columns(self, data, agg, agg_name):
         # Output dictionary
         row = {}
@@ -363,7 +391,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         row["Max MB Sent"]      = max(self.clean(data["BytesSent"], allow_empty_list=False)) / 1e6
         row["Avg MB Recv"]      = stats.mean(self.clean(data["BytesRecvd"], allow_empty_list=False)) / 1e6
         row["Max MB Recv"]      = max(self.clean(data["BytesRecvd"], allow_empty_list=False)) / 1e6
-        
+
         row["Num DAG Node Jobs"] = sum(data["_NumDAGNodes"])
         row["Max Rqst Mem MB"]  = max(self.clean(data['RequestMemory'], allow_empty_list=False))
         row["Med Used Mem MB"]  = stats.median(self.clean(data["MemoryUsage"], allow_empty_list=False))

--- a/accounting/formatters/BaseFormatter.py
+++ b/accounting/formatters/BaseFormatter.py
@@ -179,7 +179,7 @@ class BaseFormatter:
                         rows[i][j] = default_text_fmt(value)
 
         return rows
-    
+
     def get_table_html(self, table_file, report_period, start_ts, end_ts, **kwargs):
         table_data = self.load_table(table_file)
         rows = self.format_rows(table_data["header"], table_data["rows"])
@@ -188,7 +188,7 @@ class BaseFormatter:
         for i, row in enumerate(rows):
             tr_class = ["even", "odd"][i % 2]
             rows_html.append(f'<tr class="{tr_class}">{"".join(row)}</tr>')
-            
+
         newline = "\n  "
         html = f"""
 <h1>{self.get_table_title(table_file, report_period, start_ts, end_ts)}</h1>
@@ -224,7 +224,7 @@ class BaseFormatter:
 </p>
 """
         return html
-    
+
     def get_html(self):
         newline = "\n"
         html = f"""

--- a/accounting/formatters/ChtcScheddCpuFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuFormatter.py
@@ -77,7 +77,7 @@ class ChtcScheddCpuFormatter(BaseFormatter):
         }
         rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
         return rows
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"

--- a/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
@@ -73,7 +73,7 @@ class ChtcScheddCpuRemovedFormatter(BaseFormatter):
         }
         rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
         return rows
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["CPU Hours / Exec Att"] = "Average CPU Hours used in a non-final execution attempt"

--- a/accounting/formatters/ChtcScheddGpuFormatter.py
+++ b/accounting/formatters/ChtcScheddGpuFormatter.py
@@ -80,7 +80,7 @@ class ChtcScheddGpuFormatter(BaseFormatter):
         }
         rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
         return rows
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -86,10 +86,10 @@ class OsgScheddCpuFormatter(BaseFormatter):
             "Output Files Xferd / Exec Att": lambda x: f"<td>{float(x):.1f}</td>",
             "Output MB Xferd / Exec Att":    lambda x: f"<td>{float(x):.1f}</td>",
             "Output MB / File":              lambda x: f"<td>{float(x):.1f}</td>",
-            
+
         }
         return super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"

--- a/accounting/formatters/OsgScheddCpuHeldFormatter.py
+++ b/accounting/formatters/OsgScheddCpuHeldFormatter.py
@@ -52,6 +52,7 @@ HOLD_REASONS = [
     "PostScriptFailed",
     "SingularityTestFailed",
     "JobDurationExceeded",
+    "JobExecuteExceeded",
 ]
 
 def hhmm(hours):
@@ -146,7 +147,7 @@ class OsgScheddCpuHeldFormatter(BaseFormatter):
         for reason in HOLD_REASONS:
             custom_fmts[break_camel(f"% Holds for {reason}")] = lambda x: f"<td>{float(x):.1f}</td>"
         return super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"

--- a/accounting/formatters/OsgScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/OsgScheddCpuRemovedFormatter.py
@@ -77,7 +77,7 @@ class OsgScheddCpuRemovedFormatter(BaseFormatter):
         }
         rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
         return rows
-    
+
     def get_legend(self):
         custom_items = OrderedDict()
         custom_items["CPU Hours / Exec Att"] = "Average CPU Hours used in a non-final execution attempt"


### PR DESCRIPTION
Instead of just checking for flock, now checks for cm-1 and cm-2.
The code that does the checks has been overhauled quite a bit,
using set comparisons since there are now multiple hosts defined
under CollectorHost in many cases. Also, known schedds have their
CollectorHost values saved to disk so that we don't need to query
the collector(s) every time the script runs.

(Some cleanup was also done)