### PR TITLE
Fix problems with caching collector hosts

### DIFF
--- a/accounting/filters/OsgScheddCpuHeldFilter.py
+++ b/accounting/filters/OsgScheddCpuHeldFilter.py
@@ -192,27 +192,16 @@ class OsgScheddCpuHeldFilter(BaseFilter):
 
                 # Cache the CollectorHost in the map
                 if "CollectorHost" in ads[0]:
-                    collector_hosts = set()
-                    for collector_host in ads[0]["CollectorHost"].split(","):
-                        collector_hosts.add(collector_host.strip().split(":")[0])
-                    if collector_hosts:
-                        self.schedd_collector_host_map[schedd] = collector_hosts
+                    schedd_collector_hosts = set()
+                    for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                        schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                        if schedd_collector_host:
+                            schedd_collector_hosts.add(schedd_collector_host)
+                    if schedd_collector_hosts:
+                        self.schedd_collector_host_map[schedd] = schedd_collector_hosts
                         break
             else:
                 logging.warning(f"Did not find Machine == {schedd} in collectors")
-
-            # Update the pickle
-            if len(self.schedd_collector_host_map[schedd]) > 0:
-                # Don't store any unknown schedds
-                fixed_host_map = self.schedd_collector_host_map.copy()
-                delete_hosts = []
-                for k, v in fixed_host_map.items():
-                    if len(v) == 0:
-                        delete_hosts.append(k)
-                for k in delete_hosts:
-                    del fixed_host_map[k]
-                with open(self.schedd_collector_host_map_pickle, "wb") as f:
-                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
 

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -93,27 +93,16 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
 
                 # Cache the CollectorHost in the map
                 if "CollectorHost" in ads[0]:
-                    collector_hosts = set()
-                    for collector_host in ads[0]["CollectorHost"].split(","):
-                        collector_hosts.add(collector_host.strip().split(":")[0])
-                    if collector_hosts:
-                        self.schedd_collector_host_map[schedd] = collector_hosts
+                    schedd_collector_hosts = set()
+                    for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                        schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                        if schedd_collector_host:
+                            schedd_collector_hosts.add(schedd_collector_host)
+                    if schedd_collector_hosts:
+                        self.schedd_collector_host_map[schedd] = schedd_collector_hosts
                         break
             else:
                 logging.warning(f"Did not find Machine == {schedd} in collectors")
-
-            # Update the pickle
-            if len(self.schedd_collector_host_map[schedd]) > 0:
-                # Don't store any unknown schedds
-                fixed_host_map = self.schedd_collector_host_map.copy()
-                delete_hosts = []
-                for k, v in fixed_host_map.items():
-                    if len(v) == 0:
-                        delete_hosts.append(k)
-                for k in delete_hosts:
-                    del fixed_host_map[k]
-                with open(self.schedd_collector_host_map_pickle, "wb") as f:
-                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
 

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -119,27 +119,16 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
 
                 # Cache the CollectorHost in the map
                 if "CollectorHost" in ads[0]:
-                    collector_hosts = set()
-                    for collector_host in ads[0]["CollectorHost"].split(","):
-                        collector_hosts.add(collector_host.strip().split(":")[0])
-                    if collector_hosts:
-                        self.schedd_collector_host_map[schedd] = collector_hosts
+                    schedd_collector_hosts = set()
+                    for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                        schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                        if schedd_collector_host:
+                            schedd_collector_hosts.add(schedd_collector_host)
+                    if schedd_collector_hosts:
+                        self.schedd_collector_host_map[schedd] = schedd_collector_hosts
                         break
             else:
                 logging.warning(f"Did not find Machine == {schedd} in collectors")
-
-            # Update the pickle
-            if len(self.schedd_collector_host_map[schedd]) > 0:
-                # Don't store any unknown schedds
-                fixed_host_map = self.schedd_collector_host_map.copy()
-                delete_hosts = []
-                for k, v in fixed_host_map.items():
-                    if len(v) == 0:
-                        delete_hosts.append(k)
-                for k in delete_hosts:
-                    del fixed_host_map[k]
-                with open(self.schedd_collector_host_map_pickle, "wb") as f:
-                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
 

--- a/accounting/filters/OsgScheddLongJobFilter.py
+++ b/accounting/filters/OsgScheddLongJobFilter.py
@@ -166,27 +166,16 @@ class OsgScheddLongJobFilter(BaseFilter):
 
                 # Cache the CollectorHost in the map
                 if "CollectorHost" in ads[0]:
-                    collector_hosts = set()
-                    for collector_host in ads[0]["CollectorHost"].split(","):
-                        collector_hosts.add(collector_host.strip().split(":")[0])
-                    if collector_hosts:
-                        self.schedd_collector_host_map[schedd] = collector_hosts
+                    schedd_collector_hosts = set()
+                    for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                        schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                        if schedd_collector_host:
+                            schedd_collector_hosts.add(schedd_collector_host)
+                    if schedd_collector_hosts:
+                        self.schedd_collector_host_map[schedd] = schedd_collector_hosts
                         break
             else:
                 logging.warning(f"Did not find Machine == {schedd} in collectors")
-
-            # Update the pickle
-            if len(self.schedd_collector_host_map[schedd]) > 0:
-                # Don't store any unknown schedds
-                fixed_host_map = self.schedd_collector_host_map.copy()
-                delete_hosts = []
-                for k, v in fixed_host_map.items():
-                    if len(v) == 0:
-                        delete_hosts.append(k)
-                for k in delete_hosts:
-                    del fixed_host_map[k]
-                with open(self.schedd_collector_host_map_pickle, "wb") as f:
-                    pickle.dump(fixed_host_map, f)
 
         return self.schedd_collector_host_map[schedd]
 

--- a/cache_collector_hosts.py
+++ b/cache_collector_hosts.py
@@ -1,0 +1,61 @@
+import htcondor
+import pickle
+from pathlib import Path
+
+custom_mapping = {
+    "scosgdev16.jlab.org": {"scicollector.jlab.org", "osg-jlab-1.t2.ucsd.edu"},
+    "submit6.chtc.wisc.edu": {"htcondor-cm-path.osg.chtc.io"},
+    "login-el7.xenon.ci-connect.net": {"cm-2.ospool.osg-htc.org", "cm-1.ospool.osg-htc.org"},
+    "login.collab.ci-connect.net": {"cm-2.ospool.osg-htc.org", "cm-1.ospool.osg-htc.org"},
+    "uclhc-2.ps.uci.edu": {"uclhc-2.ps.uci.edu"},
+}
+
+collector_host = "cm-1.ospool.osg-htc.org"
+collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org"}
+schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
+schedd_collector_host_map = {}
+if schedd_collector_host_map_pickle.exists():
+    try:
+        schedd_collector_host_map = pickle.load(open(schedd_collector_host_map_pickle, "rb"))
+    except IOError:
+        pass
+schedd_collector_host_map.update(custom_mapping)
+
+collector = htcondor.Collector(collector_host)
+schedds = [ad["Machine"] for ad in collector.locateAll(htcondor.DaemonTypes.Schedd)]
+
+for schedd in schedds:
+    # Query Schedd ad in Collector for its CollectorHost,
+    # unless result previously cached
+    if schedd not in schedd_collector_host_map:
+        schedd_collector_host_map[schedd] = set()
+
+        for collector_host in collector_hosts:
+            collector = htcondor.Collector(collector_host)
+            ads = collector.query(
+                htcondor.AdTypes.Schedd,
+                constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
+                projection=["Machine", "CollectorHost"],
+            )
+            ads = list(ads)
+            if len(ads) == 0:
+                continue
+            if len(ads) > 1:
+                print(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
+
+            # Cache the CollectorHost in the map
+            if "CollectorHost" in ads[0]:
+                schedd_collector_hosts = set()
+                for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                    schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                    if schedd_collector_host:
+                        schedd_collector_hosts.add(schedd_collector_host)
+                if schedd_collector_hosts:
+                    schedd_collector_host_map[schedd] = schedd_collector_hosts
+                    break
+        else:
+            print(f"Did not find Machine == {schedd} in collectors")
+
+# Update the pickle
+with open(schedd_collector_host_map_pickle, "wb") as f:
+    pickle.dump(schedd_collector_host_map, f)

--- a/cache_collector_hosts.py
+++ b/cache_collector_hosts.py
@@ -2,7 +2,7 @@ import htcondor
 import pickle
 from pathlib import Path
 
-custom_mapping = {
+CUSTOM_MAPPING = {
     "scosgdev16.jlab.org": {"scicollector.jlab.org", "osg-jlab-1.t2.ucsd.edu"},
     "submit6.chtc.wisc.edu": {"htcondor-cm-path.osg.chtc.io"},
     "login-el7.xenon.ci-connect.net": {"cm-2.ospool.osg-htc.org", "cm-1.ospool.osg-htc.org"},
@@ -10,24 +10,24 @@ custom_mapping = {
     "uclhc-2.ps.uci.edu": {"uclhc-2.ps.uci.edu"},
 }
 
-collector_host = "cm-1.ospool.osg-htc.org"
-collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org"}
-schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
-schedd_collector_host_map = {}
-if schedd_collector_host_map_pickle.exists():
-    try:
-        schedd_collector_host_map = pickle.load(open(schedd_collector_host_map_pickle, "rb"))
-    except IOError:
-        pass
-schedd_collector_host_map.update(custom_mapping)
 
-collector = htcondor.Collector(collector_host)
-schedds = [ad["Machine"] for ad in collector.locateAll(htcondor.DaemonTypes.Schedd)]
+def main():
 
-for schedd in schedds:
-    # Query Schedd ad in Collector for its CollectorHost,
-    # unless result previously cached
-    if schedd not in schedd_collector_host_map:
+    collector_host = "cm-1.ospool.osg-htc.org"
+    collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org"}
+    schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
+    schedd_collector_host_map = {}
+    if schedd_collector_host_map_pickle.exists():
+        try:
+            schedd_collector_host_map = pickle.load(open(schedd_collector_host_map_pickle, "rb"))
+        except IOError:
+            pass
+    schedd_collector_host_map.update(CUSTOM_MAPPING)
+
+    collector = htcondor.Collector(collector_host)
+    schedds = [ad["Machine"] for ad in collector.locateAll(htcondor.DaemonTypes.Schedd)]
+
+    for schedd in schedds:
         schedd_collector_host_map[schedd] = set()
 
         for collector_host in collector_hosts:
@@ -56,6 +56,9 @@ for schedd in schedds:
         else:
             print(f"Did not find Machine == {schedd} in collectors")
 
-# Update the pickle
-with open(schedd_collector_host_map_pickle, "wb") as f:
-    pickle.dump(schedd_collector_host_map, f)
+    # Update the pickle
+    with open(schedd_collector_host_map_pickle, "wb") as f:
+        pickle.dump(schedd_collector_host_map, f)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There was a bug with how caching was done before with the same variables being used/overwritten. This PR fixes that and also only writes to the cache during the normal daily reports. Also, the mappings are updated every Monday in the normal daily report in case schedds change their collector hosts. Also, a script is added that can be run manually to update the cache periodically for all the current schedds reporting to the pool.