### PR TITLE
Improve report performance

### DIFF
--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -1,6 +1,7 @@
 import logging
 import statistics as stats
 from collections import defaultdict
+from functools import partial
 from operator import itemgetter
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
@@ -138,7 +139,7 @@ class BaseFilter:
         # First level - Aggregation level (e.g. Schedd, User, Project)
         # Second level - Aggregation name (e.g. value of ScheddName, UserName, ProjectName)
         # Third level - Field name to be aggregated (e.g. RemoteWallClockTime, RequestCpus)
-        filtered_data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        filtered_data = defaultdict(partial(defaultdict, partial(defaultdict, list)))
 
         # Get list of indices so we can use one at a time
         indices = list(self.client.indices.get_alias(index=es_index).keys())

--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -66,7 +66,7 @@ class BaseFilter:
         if scroll is None:
             scroll_seconds = 30 + int(5 * (((end_ts - start_ts) / (3600 * 24)) - 1)**0.5)
             scroll = f"{int(scroll_seconds)}s"
-            self.logger.info(f"No explicit scroll time set, using {scroll}.")
+            self.logger.debug(f"No explicit scroll time set, using {scroll}.")
 
         query = {
             "index": index,
@@ -144,7 +144,7 @@ class BaseFilter:
         indices = list(self.client.indices.get_alias(index=es_index).keys())
         indices.sort(reverse=True)
         indices.insert(0, indices.pop())  # make sure the first index gets checked first
-        self.logger.info(f"Querying at most {len(indices)} indices matching {es_index}.")
+        self.logger.debug(f"Querying at most {len(indices)} indices matching {es_index}.")
         got_initial_data = False  # only stop after we've seen data
 
         for index in indices:

--- a/accounting/filters/ChtcScheddCpuFilter.py
+++ b/accounting/filters/ChtcScheddCpuFilter.py
@@ -88,14 +88,12 @@ DEFAULT_FILTER_ATTRS = [
 class ChtcScheddCpuFilter(BaseFilter):
     name = "CHTC schedd job history"
 
-    def get_query(self, index, start_ts, end_ts, scroll="5s", size=500):
+    def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
         # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query = {
-            "index": index,
-            "scroll": scroll,
-            "size": size,
+        query.update({
             "body": {
                 "query": {
                     "bool": {
@@ -113,7 +111,7 @@ class ChtcScheddCpuFilter(BaseFilter):
                     }
                 }
             }
-        }
+        })
         return query
 
     def schedd_filter(self, data, doc):

--- a/accounting/filters/ChtcScheddCpuRemovedFilter.py
+++ b/accounting/filters/ChtcScheddCpuRemovedFilter.py
@@ -52,14 +52,12 @@ DEFAULT_FILTER_ATTRS = [
 class ChtcScheddCpuRemovedFilter(BaseFilter):
     name = "CHTC schedd removed job history"
 
-    def get_query(self, index, start_ts, end_ts, scroll="5s", size=500):
+    def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
         # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query = {
-            "index": index,
-            "scroll": scroll,
-            "size": size,
+        query.update({
             "body": {
                 "query": {
                     "bool": {
@@ -80,7 +78,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
                     }
                 }
             }
-        }
+        })
         return query
 
     def schedd_filter(self, data, doc):

--- a/accounting/filters/ChtcScheddGpuFilter.py
+++ b/accounting/filters/ChtcScheddGpuFilter.py
@@ -75,14 +75,12 @@ DEFAULT_FILTER_ATTRS = [
 class ChtcScheddGpuFilter(BaseFilter):
     name = "CHTC GPU schedd job history"
 
-    def get_query(self, index, start_ts, end_ts, scroll="5s", size=500):
+    def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
         # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query = {
-            "index": index,
-            "scroll": scroll,
-            "size": size,
+        query.update({
             "body": {
                 "query": {
                     "bool": {
@@ -102,7 +100,7 @@ class ChtcScheddGpuFilter(BaseFilter):
                     }
                 }
             }
-        }
+        })
         return query
 
     def schedd_filter(self, data, doc):

--- a/accounting/filters/OsgScheddCpuHeldFilter.py
+++ b/accounting/filters/OsgScheddCpuHeldFilter.py
@@ -141,14 +141,12 @@ class OsgScheddCpuHeldFilter(BaseFilter):
                 pass
         super().__init__(**kwargs)
 
-    def get_query(self, index, start_ts, end_ts, scroll="5s", size=500):
+    def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
         # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query = {
-            "index": index,
-            "scroll": scroll,
-            "size": size,
+        query.update({
             "body": {
                 "query": {
                     "bool": {
@@ -168,7 +166,7 @@ class OsgScheddCpuHeldFilter(BaseFilter):
                     }
                 }
             }
-        }
+        })
         return query
 
     def schedd_collector_host(self, schedd):

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -527,29 +527,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         return row
 
     def scan_and_filter(self, es_index, start_ts, end_ts, **kwargs):
-        filtered_data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-
-        query = self.get_query(
-            index=es_index,
-            start_ts=start_ts,
-            end_ts=end_ts,
-            scroll="10s",
-            size=600,
-        )
-
-        # Use the scan() helper function, which automatically scrolls results. Nice!
-        for doc in elasticsearch.helpers.scan(
-                client=self.client,
-                query=query.pop("body"),
-                **query,
-                ):
-
-            # Send the doc through the various filters,
-            # which mutate filtered_data in place
-            for filtr in self.get_filters():
-                filtr(filtered_data, doc)
-
-        return filtered_data
+        return super().scan_and_filter(es_index, start_ts, end_ts, build_totals=False, **kwargs)
 
     def merge_filtered_data(self, data, agg):
         # Takes filtered data and an aggregation level (e.g. Users, Schedds,

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -70,14 +70,12 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
                 pass
         super().__init__(**kwargs)
 
-    def get_query(self, index, start_ts, end_ts, scroll="5s", size=500):
+    def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
         # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query = {
-            "index": index,
-            "scroll": scroll,
-            "size": size,
+        query.update({
             "body": {
                 "query": {
                     "bool": {
@@ -95,7 +93,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
                     }
                 }
             }
-        }
+        })
         return query
 
     def schedd_collector_host(self, schedd):

--- a/accounting/filters/OsgScheddLongJobFilter.py
+++ b/accounting/filters/OsgScheddLongJobFilter.py
@@ -2,7 +2,6 @@
 import htcondor
 import pickle
 from pathlib import Path
-from collections import defaultdict
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
 from .BaseFilter import BaseFilter

--- a/send_email.py
+++ b/send_email.py
@@ -7,7 +7,7 @@ import time
 import elasticsearch
 import accounting
 from accounting.push_totals_to_es import push_totals_to_es
-import json
+import pickle
 from traceback import print_exc, print_tb
 import logging, logging.handlers
 from pathlib import Path
@@ -48,10 +48,10 @@ else:
     sys.exit(1)
 
 if args.report_period == "daily":
-    last_data_file = Path(f"last_data_{args.filter.__name__}.json")
+    last_data_file = Path(f"last_data_{args.filter.__name__}.pickle")
     logger.debug(f"Dumping data to {last_data_file}")
     with last_data_file.open("w") as f:
-        json.dump(raw_data, f, indent=2)
+        pickle.dump(raw_data, f, pickle.HIGHEST_PROTOCOL)
 
 table_names = list(raw_data.keys())
 logger.debug(f"Got {len(table_names)} tables: {', '.join(table_names)}")

--- a/send_email.py
+++ b/send_email.py
@@ -50,7 +50,7 @@ else:
 if args.report_period == "daily":
     last_data_file = Path(f"last_data_{args.filter.__name__}.pickle")
     logger.debug(f"Dumping data to {last_data_file}")
-    with last_data_file.open("w") as f:
+    with last_data_file.open("wb") as f:
         pickle.dump(raw_data, f, pickle.HIGHEST_PROTOCOL)
 
 table_names = list(raw_data.keys())


### PR DESCRIPTION
Lately we've been running into an issue where the scroll timeout
is met and where queries in general are just taking too long. Also,
writing data to a JSON file before formatting has gotten very slow
as job counts have skyrocketed. This PR aims to improve the
situation by:

1. Setting a longer scroll, which starts at 30s and scales up by
the (square root) of the number of days in the query. This shouldn't
have a huge performance impact on the rest of the operations of ES
because the scan() helper function is supposed to clear scroll ids
as it finishes with them.

2. Query one index at a time, matching the index pattern given,
until no more data is found, then stop querying. Indices are queried
in reverse (chronological) order since most of our reports are done
by looking back at the last n days of data. (The first index is also
always checked in case of a configuration error with the index alias.)
Once data is found, the next time an index returns no data, we stop
trying to query any more indices.

3. Use "_doc" sorting. Per Elasticsearch docs, this can speed up
queries (especially scrolling queries) where neither score nor sort
is important, and neither is important for these reports. We also
make sure to explicitly tell Elasticsearch that we don't want a score.

4. Put all of the above in the BaseFilter, then refactored all of the
other classes to only add what's needed to the query options coming
out of the BaseFilter's get_query method. This reduces complexity
going forward and improves understanding of which scroll and other
query options are being used across all reports.

5. Writing the unformatted data as a `pickle.HIGHEST_PROTOCOL`
pickle file instead of formatting and writing as uncompressed JSON.
Yes, it's not as nice to read and grep and whatever, but the files were
starting to get to be on the order of 10 GBs in size. This alone cuts
down the time to run the main daily OSPool report script by ~3 minutes
(depending on the amount of data).