### PR TITLE
Add shadow retry report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ lastlog*
 __pycache__
 *.pkl
 *.log
+*.pickle
+get_*.py

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -266,11 +266,11 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         if row["Num Uniq Job Ids"] > 0:
             row["Shadow Starts / Job Id"] = sum(self.clean(data["NumShadowStarts"], allow_empty_list=False)) / row["Num Uniq Job Ids"]
             row["% Jobs w/ >1 Shadow Starts"] = 100 * num_jobs_multi_shadows / row["Num Uniq Job Ids"]
-            row["% Jobs w/ >0 Xfer Input Errors"] = 100 * num_jobs_input_transfer_errors / row["Num Uniq Job Ids"]
+            row["% Jobs w/ >0 Input Xfer Errs"] = 100 * num_jobs_input_transfer_errors / row["Num Uniq Job Ids"]
         else:
             row["Shadw Starts / Job Id"] = "n/a"
             row["% Jobs w/ >1 Shadow Starts"] = "n/a"
-            row["% Jobs w/ >0 Xfer Input Errors"] = "n/a"
+            row["% Jobs w/ >0 Input Xfer Errs"] = "n/a"
         if row["Non Success Shadows (NSS)"] > 0:
             row["% NSS due to Input Xfer Errs"] = 100 * num_holds_input_transfer_errors / non_success_shadow_starts
 

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -1,0 +1,292 @@
+
+import htcondor
+import pickle
+from pathlib import Path
+from .BaseFilter import BaseFilter
+from accounting.pull_hold_reasons import get_hold_reasons
+
+
+DEFAULT_COLUMNS = {
+    10: "All CPU Hours",  # Num Uniq Job Ids
+    20: "Shadow Starts / Job Id",
+    30: "Non Success Shadows (NSS)",
+
+    50: "% Jobs w/ >1 Shadow Starts",
+    60: "% Jobs w/ >0 Input Xfer Errs",
+    70: "% NSS due to Input Xfer Errs",
+}
+
+DEFAULT_FILTER_ATTRS = [
+    "NumShadowStarts",
+    "NumHolds",
+    "NumHoldsByReason",
+    "JobStatus",
+]
+
+class OsgScheddCpuRetryFilter(BaseFilter):
+    name = "OSG schedd retried job history"
+    
+    def __init__(self, **kwargs):
+        self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}
+        self.schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
+        self.schedd_collector_host_map = {}
+        if self.schedd_collector_host_map_pickle.exists():
+            try:
+                self.schedd_collector_host_map = pickle.load(open(self.schedd_collector_host_map_pickle, "rb"))
+            except IOError:
+                pass
+        super().__init__(**kwargs)
+
+    def get_query(self, index, start_ts, end_ts, **kwargs):
+        # Returns dict matching Elasticsearch.search() kwargs
+        # (Dict has same structure as the REST API query language)
+        query = super().get_query(index, start_ts, end_ts, **kwargs)
+
+        query.update({
+            "body": {
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"range": {
+                                "RecordTime": {
+                                    "gte": start_ts,
+                                    "lt": end_ts,
+                                }
+                            }},
+                            {"range": {
+                                "NumShadowStarts": {
+                                    "gt": 0,
+                                }
+                            }},
+                            {"term": {
+                                "JobUniverse": 5,
+                            }},
+                        ]
+                    }
+                }
+            }
+        })
+        return query
+
+    def schedd_collector_host(self, schedd):
+        # Query Schedd ad in Collector for its CollectorHost,
+        # unless result previously cached
+        if schedd not in self.schedd_collector_host_map:
+            self.schedd_collector_host_map[schedd] = set()
+
+            for collector_host in self.collector_hosts:
+                if collector_host in {"flock.opensciencegrid.org"}:
+                    continue
+                collector = htcondor.Collector(collector_host)
+                ads = collector.query(
+                    htcondor.AdTypes.Schedd,
+                    constraint=f'''Machine == "{schedd.split('@')[-1]}"''',
+                    projection=["CollectorHost"],
+                )
+                ads = list(ads)
+                if len(ads) == 0:
+                    continue
+                if len(ads) > 1:
+                    self.logger.warning(f'Got multiple Schedd ClassAds for Machine == "{schedd}"')
+
+                # Cache the CollectorHost in the map
+                if "CollectorHost" in ads[0]:
+                    schedd_collector_hosts = set()
+                    for schedd_collector_host in ads[0]["CollectorHost"].split(","):
+                        schedd_collector_host = schedd_collector_host.strip().split(":")[0]
+                        if schedd_collector_host:
+                            schedd_collector_hosts.add(schedd_collector_host)
+                    if schedd_collector_hosts:
+                        self.schedd_collector_host_map[schedd] = schedd_collector_hosts
+                        break
+            else:
+                self.logger.warning(f"Did not find Machine == {schedd} in collectors")
+
+        return self.schedd_collector_host_map[schedd]
+
+    def is_ospool_job(self, ad):
+        remote_pool = set()
+        if "LastRemotePool" in ad and ad["LastRemotePool"]:
+            remote_pool.add(ad["LastRemotePool"])
+        else:
+            schedd = ad.get("ScheddName", "UNKNOWN") or "UNKNOWN"
+            if schedd != "UNKNOWN":
+                remote_pool = self.schedd_collector_host(schedd)
+        return bool(remote_pool & self.collector_hosts)
+
+    def schedd_filter(self, data, doc):
+
+        # Get input dict
+        i = doc["_source"]
+
+        # Get output dict for this schedd
+        schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
+        o = data["Schedds"][schedd]
+
+        # Filter out jobs that did not run in the OS pool        
+        if not self.is_ospool_job(i):
+            return
+
+        # Get list of attrs
+        filter_attrs = DEFAULT_FILTER_ATTRS.copy()
+
+        # Count number of history ads (i.e. number of unique job ids)
+        o["_NumJobs"].append(1)
+
+        # Add attr values to the output dict, use None if missing
+        for attr in filter_attrs:
+            o[attr].append(i.get(attr, None))
+
+    def user_filter(self, data, doc):
+
+        # Get input dict
+        i = doc["_source"]
+
+        # Get output dict for this user
+        user = i.get("User", "UNKNOWN") or "UNKNOWN"
+        o = data["Users"][user]
+
+        # Filter out jobs that did not run in the OS pool
+        if not self.is_ospool_job(i):
+            return
+
+        # Add custom attrs to the list of attrs
+        filter_attrs = DEFAULT_FILTER_ATTRS.copy()
+        filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
+
+        # Count number of history ads (i.e. number of unique job ids)
+        o["_NumJobs"].append(1)
+
+        # Add attr values to the output dict, use None if missing
+        for attr in filter_attrs:
+            # Use UNKNOWN for missing or blank ProjectName and ScheddName
+            if attr in ["ScheddName", "ProjectName"]:
+                o[attr].append(i.get(attr, "UNKNOWN") or "UNKNOWN")
+            else:
+                o[attr].append(i.get(attr, None))
+
+    def project_filter(self, data, doc):
+
+        # Get input dict
+        i = doc["_source"]
+
+        # Get output dict for this project
+        project = i.get("ProjectName", "UNKNOWN") or "UNKNOWN"
+        o = data["Projects"][project]
+
+        # Filter out jobs that did not run in the OS pool
+        if not self.is_ospool_job(i):
+            return
+
+        # Add custom attrs to the list of attrs
+        filter_attrs = DEFAULT_FILTER_ATTRS.copy()
+        filter_attrs = filter_attrs + ["User"]
+
+        # Count number of history ads (i.e. number of unique job ids)
+        o["_NumJobs"].append(1)
+
+        # Add attr values to the output dict, use None if missing
+        for attr in filter_attrs:
+            o[attr].append(i.get(attr, None))
+
+    def get_filters(self):
+        # Add all filter methods to a list
+        filters = [
+            self.schedd_filter,
+            self.user_filter,
+            self.project_filter,
+        ]
+        return filters
+
+    def add_custom_columns(self, agg):
+        # Add Project and Schedd columns to the Users table
+        columns = DEFAULT_COLUMNS.copy()
+        if agg == "Users":
+            columns[5] = "Most Used Project"
+            columns[175] = "Most Used Schedd"
+        if agg == "Projects":
+            columns[5] = "Num Users"
+        return columns
+
+    def merge_filtered_data(self, data, agg):
+        rows = super().merge_filtered_data(data, agg)
+        columns_sorted = list(rows[0])
+        columns_sorted[columns_sorted.index("All CPU Hours")] = "Num Uniq Job Ids"
+        rows[0] = tuple(columns_sorted)
+        return rows
+
+    def compute_custom_columns(self, data, agg, agg_name):
+
+        # Output dictionary
+        row = {}
+
+        # Compute non successful shadow starts
+        non_success_shadow_starts = 0
+        num_jobs_multi_shadows = 0
+        for (
+                num_shadow_starts,
+                job_status
+            ) in zip(
+                data["NumShadowStarts"],
+                data["JobStatus"]
+            ):
+            if None in [num_shadow_starts, job_status]:
+                continue
+
+            if num_shadow_starts > 1:
+                num_jobs_multi_shadows += 1
+            if job_status == 3:  # removed jobs never succeeded
+                non_success_shadow_starts += num_shadow_starts
+            else:  # assume last shadow start succeeded
+                non_success_shadow_starts += max(0, num_shadow_starts - 1)
+
+        # Compute transfer input hold counts
+        transfer_input_error_reasons = {
+            "TransferInputError",
+            "UploadFileError",
+        }
+        num_holds_input_transfer_errors = 0
+        num_jobs_input_transfer_errors = 0
+        condor_hold_reasons = get_hold_reasons()
+        for job_hold_reasons in data["NumHoldsByReason"]:
+            if transfer_input_error_reasons & set(job_hold_reasons):
+                transfer_input_holds = sum([
+                    int(job_hold_reasons.get(reason, 0))
+                    for reason in transfer_input_error_reasons
+                ])
+                num_holds_input_transfer_errors += transfer_input_holds
+                num_jobs_input_transfer_errors += int(transfer_input_holds > 0)
+
+        # Compute columns
+        row["Num Uniq Job Ids"] = sum(data["_NumJobs"])
+        row["Non Success Shadows (NSS)"] = non_success_shadow_starts
+        if row["Num Uniq Job Ids"] > 0:
+            row["Shadw Starts / Job Id"] = sum(self.clean(data["NumShadowStarts"], allow_empty_list=False)) / row["Num Uniq Job Ids"]
+            row["% Jobs w/ >1 Shadow Starts"] = 100 * num_jobs_multi_shadows / row["Num Uniq Job Ids"]
+            row["% Jobs w/ >0 Xfer Input Errors"] = 100 * num_jobs_transfer_errors / row["Num Uniq Job Ids"]
+        else:
+            row["Shadw Starts / Job Id"] = "n/a"
+            row["% Jobs w/ >1 Shadow Starts"] = "n/a"
+            row["% Jobs w/ >0 Xfer Input Errors"] = "n/a"
+        if row["Non Success Shadows (NSS)"] > 0:
+            row["% NSS due to Input Xfer Errs"] = 100 * num_holds_input_transfer_errors / non_success_shadow_starts
+
+        # Compute mode for Project and Schedd columns in the Users table
+        if agg == "Users":
+            projects = self.clean(data["ProjectName"])
+            if len(projects) > 0:
+                row["Most Used Project"] = max(set(projects), key=projects.count)
+            else:
+                row["Most Used Project"] = "UNKNOWN"
+
+            schedds = self.clean(data["ScheddName"])
+            if len(schedds) > 0:
+                row["Most Used Schedd"] = max(set(schedds), key=schedds.count)
+            else:
+                row["Most Used Schedd"] = "UNKNOWN"
+        if agg == "Projects":
+            row["Num Users"] = len(set(data["User"]))  
+
+        row["All CPU Hours"] = row["Num Uniq Job Ids"]
+
+        return row 

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -266,7 +266,7 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         if row["Num Uniq Job Ids"] > 0:
             row["Shadw Starts / Job Id"] = sum(self.clean(data["NumShadowStarts"], allow_empty_list=False)) / row["Num Uniq Job Ids"]
             row["% Jobs w/ >1 Shadow Starts"] = 100 * num_jobs_multi_shadows / row["Num Uniq Job Ids"]
-            row["% Jobs w/ >0 Xfer Input Errors"] = 100 * num_jobs_transfer_errors / row["Num Uniq Job Ids"]
+            row["% Jobs w/ >0 Xfer Input Errors"] = 100 * num_jobs_input_transfer_errors / row["Num Uniq Job Ids"]
         else:
             row["Shadw Starts / Job Id"] = "n/a"
             row["% Jobs w/ >1 Shadow Starts"] = "n/a"

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -273,6 +273,8 @@ class OsgScheddCpuRetryFilter(BaseFilter):
             row["% Jobs w/ >0 Input Xfer Errs"] = "n/a"
         if row["Non Success Shadows (NSS)"] > 0:
             row["% NSS due to Input Xfer Errs"] = 100 * num_holds_input_transfer_errors / non_success_shadow_starts
+        else:
+            row["% NSS due to Input Xfer Errs"] = "n/a"
 
         # Compute mode for Project and Schedd columns in the Users table
         if agg == "Users":

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -249,6 +249,9 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         num_jobs_input_transfer_errors = 0
         condor_hold_reasons = get_hold_reasons()
         for job_hold_reasons in data["NumHoldsByReason"]:
+            if job_hold_reasons is None:
+                continue
+
             if transfer_input_error_reasons & set(job_hold_reasons):
                 transfer_input_holds = sum([
                     int(job_hold_reasons.get(reason, 0))

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -264,7 +264,7 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         row["Num Uniq Job Ids"] = sum(data["_NumJobs"])
         row["Non Success Shadows (NSS)"] = non_success_shadow_starts
         if row["Num Uniq Job Ids"] > 0:
-            row["Shadw Starts / Job Id"] = sum(self.clean(data["NumShadowStarts"], allow_empty_list=False)) / row["Num Uniq Job Ids"]
+            row["Shadow Starts / Job Id"] = sum(self.clean(data["NumShadowStarts"], allow_empty_list=False)) / row["Num Uniq Job Ids"]
             row["% Jobs w/ >1 Shadow Starts"] = 100 * num_jobs_multi_shadows / row["Num Uniq Job Ids"]
             row["% Jobs w/ >0 Xfer Input Errors"] = 100 * num_jobs_input_transfer_errors / row["Num Uniq Job Ids"]
         else:

--- a/accounting/filters/__init__.py
+++ b/accounting/filters/__init__.py
@@ -7,3 +7,4 @@ from .ChtcScheddCpuFilter import ChtcScheddCpuFilter
 from .ChtcScheddCpuRemovedFilter import ChtcScheddCpuRemovedFilter
 from .ChtcScheddGpuFilter import ChtcScheddGpuFilter
 from .OsgScheddLongJobFilter import OsgScheddLongJobFilter
+from .OsgScheddCpuRetryFilter import OsgScheddCpuRetryFilter

--- a/accounting/formatters/OsgScheddCpuRetryFormatter.py
+++ b/accounting/formatters/OsgScheddCpuRetryFormatter.py
@@ -1,0 +1,63 @@
+from .BaseFormatter import BaseFormatter
+from datetime import datetime
+from collections import OrderedDict
+
+
+class OsgScheddCpuRetryFormatter(BaseFormatter):
+
+    def get_table_title(self, table_file, report_period, start_ts, end_ts):
+        info = self.parse_table_filename(table_file)
+        # Format date(s)
+        start = datetime.fromtimestamp(start_ts)
+        if report_period in ["daily"]:
+            start_date = start.strftime("%Y-%m-%d")
+            title_str = f"OSPool per {info['agg'].rstrip('s')} usage for jobs completed on <strong>{start_date}</strong>"
+        elif report_period in ["weekly", "monthly"]:
+            end = datetime.fromtimestamp(end_ts)
+            start_date = start.strftime("%Y-%m-%d")
+            end_date = end.strftime("%Y-%m-%d")
+            title_str = f"OSPool per {info['agg'].rstrip('s')} usage for jobs completed from <strong>{start_date} to {end_date}</strong>"
+        else:
+            end = datetime.fromtimestamp(end_ts)
+            start_date = start.strftime("%Y-%m-%d %H:%M:%S")
+            end_date = end.strftime("%Y-%m-%d %H:%M:%S")
+            title_str = f"OSPool per {info['agg'].rstrip('s')} usage for jobs completed from <strong>{start_date} to {end_date}</strong>"
+        return title_str
+
+    def get_subject(self, report_period, start_ts, end_ts, **kwargs):
+        # Format date(s)
+        start = datetime.fromtimestamp(start_ts)
+        if report_period in ["daily", "weekly", "monthly"]:
+            start_date = start.strftime("%Y-%m-%d")
+            subject_str = f"OSPool {report_period.capitalize()} Shadow Retry Report {start_date}"
+        else:
+            end = datetime.fromtimestamp(end_ts)
+            start_date = start.strftime("%Y-%m-%d %H:%M:%S")
+            end_date = end.strftime("%Y-%m-%d %H:%M:%S")
+            subject_str = f"OSPool Shadow Retry Report {start_date} to {end_date}"
+        return subject_str
+
+    def rm_cols(self, data):
+        cols = {}
+        return super().rm_cols(data, cols=cols)
+
+    def format_rows(self, header, rows, custom_fmts={}, default_text_fmt=None, default_numeric_fmt=None):
+        custom_fmts = {
+            "Shadow Starts / Job Id":       lambda x: f"<td>{float(x):.2f}</td>",
+            "% Jobs w/ >1 Shadow Starts":   lambda x: f"<td>{float(x):.1f}</td>",
+            "% Jobs w/ >0 Input Xfer Errs": lambda x: f"<td>{float(x):.1f}</td>",
+            "% NSS due to Input Xfer Errs": lambda x: f"<td>{float(x):.1f}</td>",
+        }
+        rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
+        return rows
+
+    def get_legend(self):
+        custom_items = OrderedDict()
+        custom_items["Shadow Starts / Job Id"]   = "Shadow starts per job (that had at least one shadow start)"
+        custom_items["Non Success Shadows (NSS)"] = "Shadow starts that did not result in job completion"
+        custom_items["% Jobs w/ >1 Shadow Starts"] = "Percentage of jobs that had multiple shadow starts"
+        custom_items["% Jobs w/ >0 Input Xfer Errs"] = "Percentage of jobs that had at least one transfer input error"
+        custom_items["% NSS due to Input Xfer Errs"] = "Percentage of NSS's that were related to transfer input error"
+        html = super().get_legend(custom_items)
+        return html
+

--- a/accounting/formatters/__init__.py
+++ b/accounting/formatters/__init__.py
@@ -6,3 +6,4 @@ from .ChtcScheddCpuFormatter import ChtcScheddCpuFormatter
 from .ChtcScheddCpuRemovedFormatter import ChtcScheddCpuRemovedFormatter
 from .ChtcScheddGpuFormatter import ChtcScheddGpuFormatter
 from .OsgScheddLongJobFormatter import OsgScheddLongJobFormatter
+from .OsgScheddCpuRetryFormatter import OsgScheddCpuRetryFormatter

--- a/accounting/pull_hold_reasons.py
+++ b/accounting/pull_hold_reasons.py
@@ -31,7 +31,7 @@ def parse_latest_hold_reasons():
         if line.rstrip().endswith("*/"):
             in_comment_block = False
             continue
-        if in_comment:
+        if in_comment_block:
             continue
         if line.lstrip().startswith("#") or line.lstrip().startswith("//"):
             continue

--- a/accounting/pull_hold_reasons.py
+++ b/accounting/pull_hold_reasons.py
@@ -1,0 +1,75 @@
+import pickle
+import tempfile
+import os
+import time
+import re
+from urllib.request import urlopen
+from pathlib import Path
+
+
+CONDOR_HOLDCODES_URL = "https://raw.githubusercontent.com/htcondor/htcondor/main/src/condor_utils/condor_holdcodes.h"
+HOLD_REASONS_PICKLE = Path("hold_reasons.pkl")
+HOLD_REASON_RE = re.compile(r"\s*(\w+)\s*=\s*(\d+)\s*,?")
+
+
+def parse_latest_hold_reasons():
+    """Gets latest hold reasons"""
+
+    hold_reasons = {}
+    condor_holdcodes_h = urlopen(CONDOR_HOLDCODES_URL)
+    in_comment_block = False
+
+    for line in condor_holdcodes_h:
+        try:
+            line = line.decode()
+        except RuntimeError:
+            continue
+        if line.strip() == "":
+            continue
+        if line.lstrip().startswith("/*"):
+            in_comment_block = True
+        if line.rstrip().endswith("*/"):
+            in_comment_block = False
+            continue
+        if in_comment:
+            continue
+        if line.lstrip().startswith("#") or line.lstrip().startswith("//"):
+            continue
+
+        match = HOLD_REASON_RE.match(line)
+        if match:
+            hold_reasons[match.group(1)] = int(match.group(2))
+
+    return hold_reasons
+
+
+def update_hold_reasons_pickle(hold_reasons_pickle):
+    """Updates (or creates) hold reason pickle file"""
+
+    hold_reasons = parse_latest_hold_reasons()
+
+    # Write atomically
+    with tempfile.NamedTemporaryFile(delete=False, dir=str(Path.cwd())) as tf:
+        tmpfile = Path(tf.name)
+        with tmpfile.open("wb") as f:
+            pickle.dump(hold_reasons, f)
+            f.flush()
+            os.fsync(f.fileno())
+    tmpfile.rename(hold_reasons_pickle)
+
+
+def get_hold_reasons(hold_reasons_pickle=HOLD_REASONS_PICKLE, force_update=False):
+    """Returns hold reasons, updated if needed"""
+
+    if force_update:
+        update_hold_reasons_pickle(hold_reasons_pickle)
+    try:
+        hold_reasons = pickle.load(hold_reasons_pickle.open("rb"))
+    except FileNotFoundError:
+        update_hold_reasons_pickle(hold_reasons_pickle)
+        hold_reasons = pickle.load(hold_reasons_pickle.open("rb"))
+    return hold_reasons
+
+
+if __name__ == "__main__":
+    print(get_hold_reasons(force_update=True))


### PR DESCRIPTION
Adds a shadow retry report, and breaks down the number of extra shadows that were needed per project/user/AP by if they were related to transfer input errors. Still a bit of a work in progress, will update as more specs come in for this report.