### PR TITLE
OSDF transfers reporting/non-reporting APs (INF-1416)

### DIFF
--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -837,11 +837,14 @@ class OsgScheddCpuFilter(BaseFilter):
                 row["Total Files Xferd"] = row.get("Total Files Xferd", 0) + output_files
 
         if osdf_files_count == 0 or osdf_bytes_total == 0:
-            condor_version = tuple([int(x) for x in data["CondorVersion"].split()[1].split(".")])
-            if condor_version > (9, 7, 0):
-                row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = 0
+            condor_versions_set = set(data["CondorVersion"])
+            condor_versions_tuples_list = []
+            for version in condor_versions_set:
+                condor_versions_tuples_list.append(tuple([int(x) for x in version.split()[1].split(".")]))
+            if all(condor_version_tuple < (9, 7, 0) for condor_version_tuple in condor_versions_tuples_list):
+                row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = "-"
             else:
-                row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = "-"                
+                row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = 0                    
         else:
             row["OSDF Files Xferd"] = osdf_files_count or ""
             if osdf_files_count > 0 and osdf_bytes_total > 0 and total_files > 0 and total_bytes > 0:

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -853,12 +853,12 @@ class OsgScheddCpuFilter(BaseFilter):
             else:
                 row["% OSDF Files"] = row["% OSDF Bytes"] = ""
 
-            # Insert missing value if any missing
-            for key in ["Total Files Xferd", "Total Input Files", "Total Output Files",
-                        "Input Files / Exec Att", "Output Files / Job",
-                        "Input MB / Exec Att", "Output MB / Job",
-                        "Input MB / File", "Output MB / File"]:
-                row[key] = row.get(key, -999)
+        # Insert missing value if any missing
+        for key in ["Total Files Xferd", "Total Input Files", "Total Output Files",
+                    "Input Files / Exec Att", "Output Files / Job",
+                    "Input MB / Exec Att", "Output MB / Job",
+                    "Input MB / File", "Output MB / File"]:
+            row[key] = row.get(key, -999)
 
         # Compute activation time stats
         row["Mean Actv Hrs"] = ""

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -837,9 +837,8 @@ class OsgScheddCpuFilter(BaseFilter):
                 row["Total Files Xferd"] = row.get("Total Files Xferd", 0) + output_files
 
         if osdf_files_count == 0 or osdf_bytes_total == 0:
-            version_string = str(data["CondorVersion"])
-            version_numbers = version_string.split()[0].split(".")
-            if version_numbers[0] > 9 or (version_numbers[0] == 9 and version_numbers[1] >= 7):
+            condor_version = tuple([int(x) for x in data["CondorVersion"].split()[1].split(".")])
+            if condor_version > (9, 7, 0):
                 row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = 0
             else:
                 row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = "-"                


### PR DESCRIPTION
Changes reporting for OSDF data transfers to be "0" if there were no OSDF files or bytes transferred and the CondorVersion was >= 9.7.0 and "-" if there were no OSDF files or bytes transferred but the CondorVersion was < 9.7.0