### PR TITLE
INF-1520 Expand legend entries for activation setup time

### DIFF
--- a/accounting/formatters/ChtcScheddCpuFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuFormatter.py
@@ -114,7 +114,7 @@ class ChtcScheddCpuFormatter(BaseFormatter):
         custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
-        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds)"
+        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."
 
         custom_items["Min/25%/Median/75%/Max/Mean/Std Hrs"] = "Final execution wallclock hours that a non-short job (Min-Max) or jobs (Mean/Std) ran for (excluding Short jobs, excluding Local and Scheduler Universe jobs)"
 

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -147,7 +147,7 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
-        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds)"
+        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."
 
         custom_items["Min/25%/Median/75%/Max/Mean/Std Hrs"] = "Final execution wallclock hours that a non-short job (Min-Max) or jobs (Mean/Std) ran for (excluding Short jobs, excluding Local and Scheduler Universe jobs)"
 

--- a/accounting/formatters/OsgScheddGpuFormatter.py
+++ b/accounting/formatters/OsgScheddGpuFormatter.py
@@ -150,7 +150,7 @@ class OsgScheddGpuFormatter(BaseFormatter):
         custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
-        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds)"
+        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."
 
         custom_items["Min/25%/Median/75%/Max/Mean/Std Hrs"] = "Final execution wallclock hours that a non-short job (Min-Max) or jobs (Mean/Std) ran for (excluding Short jobs, excluding Local and Scheduler Universe jobs)"
 

--- a/accounting/formatters/PathScheddCpuFormatter.py
+++ b/accounting/formatters/PathScheddCpuFormatter.py
@@ -114,7 +114,7 @@ class PathScheddCpuFormatter(BaseFormatter):
         custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
-        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds)"
+        custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."
 
         custom_items["Min/25%/Median/75%/Max/Mean/Std Hrs"] = "Final execution wallclock hours that a non-short job (Min-Max) or jobs (Mean/Std) ran for (excluding Short jobs, excluding Local and Scheduler Universe jobs)"
 


### PR DESCRIPTION
Miron would like the definition of this column spelled out in the legend. For reference, this is what the manual says:

> ActivationSetupDuration
> Formally, the length of time in seconds from when the shadow sends a claim activation to when the shadow is notified that > the job was spawned.
>
> Informally, this is how long it took the starter to prepare to execute the job. That includes file transfer (including the time required to wait in the transfer queue), so the difference between this duration and the duration of input file transfer is (roughly) the execute-side overhead of preparing to start the job.