### PR TITLE
handle TOTAL row not existing exception

### DIFF
--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -310,7 +310,10 @@ class BaseFilter:
             rows.sort(reverse=True, key=itemgetter(columns_sorted.index("All GPU Hours")))
 
         # Ensure the TOTAL row is at the top
-        rows.insert(0, rows.pop(list(row[0] for row in rows).index("TOTAL")))
+        try:
+            rows.insert(0, rows.pop(list(row[0] for row in rows).index("TOTAL")))
+        except ValueError:
+            pass
 
         # Prepend the header row
         rows.insert(0, tuple(columns_sorted))


### PR DESCRIPTION
The previous fix for the position of the TOTAL row doesn't account for that row not existing, which occurs when there were not jobs for a given category/time-span, such as daily OSPool GPU usage.