### PR TITLE
(INF-1855) Report Column Shifts

### DIFF
--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -16,20 +16,19 @@ DEFAULT_COLUMNS = {
 
     45: "% Ckpt Able",
     50: "% Rm'd Jobs",
-    55: "Total Files Xferd",
-    56: "OSDF Files Xferd",
-    57: "% OSDF Files",
-    58: "% OSDF Bytes",
+    51: "Total Files Xferd",
+    52: "OSDF Files Xferd",
+    53: "% OSDF Files",
+    54: "% OSDF Bytes",
+    55: "Shadw Starts / Job Id",
+    56: "Exec Atts / Shadw Start",
+    57: "Holds / Job Id",
+
     60: "% Short Jobs",
     70: "% Jobs w/>1 Exec Att",
     80: "% Jobs w/1+ Holds",
     81: "% Jobs Over Rqst Disk",
     82: "% Jobs using S'ty",
-    
-
-    88: "Shadw Starts / Job Id",
-    90: "Exec Atts / Shadw Start",
-    95: "Holds / Job Id",
 
     100: "Mean Actv Hrs",
     105: "Mean Setup Secs",
@@ -435,7 +434,7 @@ class OsgScheddCpuFilter(BaseFilter):
         if agg == "Institution":
             columns[4] = "Num Sites"
             columns[5] = "Num Users"
-            rm_columns = [30,45,50,55,56,57,58,70,80,88,90,95,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,370,380,390]
+            rm_columns = [30,45,50,51,52,53,54,55,56,57,70,80,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,370,380,390]
             [columns.pop(key) for key in rm_columns if key in columns]
         return columns
 

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -49,13 +49,6 @@ DEFAULT_COLUMNS = {
 #    191: "Output MB / Job",
 #    192: "Output MB / File",
 
-    200: "Max Rqst Mem MB",
-    210: "Med Used Mem MB",
-    220: "Max Used Mem MB",
-    225: "Max Rqst Disk GB",
-    227: "Max Used Disk GB",
-    230: "Max Rqst Cpus",
-
     300: "Good CPU Hours",
     305: "CPU Hours / Bad Exec Att",
     310: "Num Exec Atts",
@@ -71,6 +64,13 @@ DEFAULT_COLUMNS = {
     380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
+
+    500: "Max Rqst Mem MB",
+    510: "Med Used Mem MB",
+    520: "Max Used Mem MB",
+    525: "Max Rqst Disk GB",
+    527: "Max Used Disk GB",
+    530: "Max Rqst Cpus",
 }
 
 

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -21,19 +21,19 @@ DEFAULT_COLUMNS = {
 
     45: "% Ckpt Able",
     50: "% Rm'd Jobs",
-    55: "Total Files Xferd",
-    56: "OSDF Files Xferd",
-    57: "% OSDF Files",
-    58: "% OSDF Bytes",
+    51: "Total Files Xferd",
+    52: "OSDF Files Xferd",
+    53: "% OSDF Files",
+    54: "% OSDF Bytes",
+    55: "Shadw Starts / Job Id",
+    56: "Exec Atts / Shadw Start",
+    57: "Holds / Job Id",
+
     60: "% Short Jobs",
     70: "% Jobs w/>1 Exec Att",
     80: "% Jobs w/1+ Holds",
     81: "% Jobs Over Rqst Disk",
     82: "% Jobs using S'ty",
-
-    88: "Shadw Starts / Job Id",
-    90: "Exec Atts / Shadw Start",
-    95: "Holds / Job Id",
 
     110: "Min Hrs",
     150: "Max Hrs",
@@ -392,7 +392,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         if agg == "Institution":
             columns[4] = "Num Sites"
             columns[5] = "Num Users"
-            rm_columns = [30,45,50,55,56,57,58,70,80,88,90,95,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,370,380,390]
+            rm_columns = [30,45,50,51,52,53,54,55,56,57,70,80,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,370,380,390]
             [columns.pop(key) for key in rm_columns if key in columns]
         return columns
 

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -46,12 +46,6 @@ DEFAULT_COLUMNS = {
 #    191: "Output MB / Job",
 #    192: "Output MB / File",
 
-    200: "Max Rqst Mem MB",
-    220: "Max Used Mem MB",
-    225: "Max Rqst Disk GB",
-    227: "Max Used Disk GB",
-    230: "Max Rqst Cpus",
-
     300: "Good CPU Hours",
     305: "CPU Hours / Bad Exec Att",
     310: "Num Exec Atts",
@@ -67,6 +61,12 @@ DEFAULT_COLUMNS = {
     380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
+
+    500: "Max Rqst Mem MB",
+    520: "Max Used Mem MB",
+    525: "Max Rqst Disk GB",
+    527: "Max Used Disk GB",
+    530: "Max Rqst Cpus",
 }
 
 

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -18,18 +18,19 @@ DEFAULT_COLUMNS = {
 
     45: "% Ckpt Able",
     50: "% Rm'd Jobs",
-    55: "Total Files Xferd",
-    56: "OSDF Files Xferd",
-    57: "% OSDF Files",
-    58: "% OSDF Bytes",
+    51: "Total Files Xferd",
+    52: "OSDF Files Xferd",
+    53: "% OSDF Files",
+    54: "% OSDF Bytes",
+    55: "Shadw Starts / Job Id",
+    56: "Exec Atts / Shadw Start",
+    57: "Holds / Job Id",
+
     60: "% Short Jobs",
     70: "% Jobs w/>1 Exec Att",
     80: "% Jobs w/1+ Holds",
     81: "% Jobs Over Rqst Disk",
     82: "% Jobs using S'ty",
-
-    88: "Shadw Starts / Job Id",
-    90: "Exec Atts / Shadw Start",
 
     110: "Min Hrs",
     120: "25% Hrs",
@@ -435,7 +436,7 @@ class OsgScheddGpuFilter(BaseFilter):
         if agg == "Institution":
             columns[4] = "Num Sites"
             columns[5] = "Num Users"
-            rm_columns = [30,35,45,50,55,56,57,58,70,80,88,90,180,181,190,191,300,303,305,307,310,320,330,340,350,390]
+            rm_columns = [30,35,45,50,51,52,53,54,55,56,57,70,80,180,181,190,191,300,303,305,307,310,320,330,340,350,390]
             [columns.pop(key) for key in rm_columns if key in columns]
         return columns
 

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -48,14 +48,6 @@ DEFAULT_COLUMNS = {
 #    191: "Output MB / Job",
 #    192: "Output MB / File",
 
-    200: "Max Rqst Mem MB",
-    210: "Med Used Mem MB",
-    220: "Max Used Mem MB",
-    225: "Max Rqst Disk GB",
-    227: "Max Used Disk GB",
-    230: "Max Rqst Cpus",
-    240: "Max Rqst Gpus",
-
     300: "Good CPU Hours",
     303: "Good GPU Hours",
     305: "CPU Hours / Bad Exec Att",
@@ -67,6 +59,14 @@ DEFAULT_COLUMNS = {
     350: "Num Jobs w/>1 Exec Att",
     360: "Num Short Jobs",
     390: "Num Ckpt Able Jobs",
+
+    500: "Max Rqst Mem MB",
+    510: "Med Used Mem MB",
+    520: "Max Used Mem MB",
+    525: "Max Rqst Disk GB",
+    527: "Max Used Disk GB",
+    530: "Max Rqst Cpus",
+    540: "Max Rqst Gpus",
 }
 
 

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -135,16 +135,16 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["OSDF Files Xferd"] = "Total files transferred using the OSDF (f.k.a. Stash) transfer plugin. A dash (-) in this column means that no APs associated with this data had the capability to transfer files with the OSDF, whereas a zero (0) means that no OSDF file transfers occurred (though OSDF file transfers were possible)."
         custom_items["% OSDF Files"] = "Percent of all transferred files that were transferred using the OSDF plugin"
         custom_items["% OSDF Bytes"] = "Percent of all transferred bytes that were transferred using the OSDF plugin"
+        custom_items["Shadw Starts / Job Id"]   = "Num Shadw Starts per Num Uniq Job Ids"
+        custom_items["Exec Atts / Shadw Start"] = "Num Exec Atts per Num Shadw Starts"
+        custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
+
         custom_items["% Short Jobs"] = "Percent of Num Uniq Job Ids that were short jobs"
         custom_items["% Jobs w/>1 Exec Att"] = "Percent of Num Uniq Job Ids that had more than one execution attempt"
         custom_items["% Jobs w/1+ Holds"] = "Percent of Num Uniq Job Ids that had one or more jobs go on hold"
         custom_items["% Jobs Over Rqst Disk"] = "Percent of Num Uniq Job Ids that went over their requested disk space"
         custom_items["% Jobs using S'ty"] = "Percent of Num Uniq Job Ids that requested to run inside a Singularity image"
         custom_items["% Ckpt Able"] = "Percent of Num Uniq Job Ids that may be using user-level checkpointing"
-
-        custom_items["Shadw Starts / Job Id"]   = "Num Shadw Starts per Num Uniq Job Ids"
-        custom_items["Exec Atts / Shadw Start"] = "Num Exec Atts per Num Shadw Starts"
-        custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
         custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -159,12 +159,13 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["Output MB / Job"] = "Average size (in MB) of output sandboxes"
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
-        custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
-        custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"
-
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
         custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
         custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
+
+        custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
+        custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"
+
         html = super().get_legend(custom_items)
         return html
 

--- a/accounting/formatters/OsgScheddGpuFormatter.py
+++ b/accounting/formatters/OsgScheddGpuFormatter.py
@@ -162,12 +162,13 @@ class OsgScheddGpuFormatter(BaseFormatter):
         custom_items["Output MB / Job"] = "Average size (in MB) of output sandboxes"
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
-        custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
-        custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"
-
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
         custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
         custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
+
+        custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
+        custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"
+
         html = super().get_legend(custom_items)
         return html
 

--- a/accounting/formatters/OsgScheddGpuFormatter.py
+++ b/accounting/formatters/OsgScheddGpuFormatter.py
@@ -138,16 +138,16 @@ class OsgScheddGpuFormatter(BaseFormatter):
         custom_items["OSDF Files Xferd"] = "Total files transferred using the OSDF (f.k.a. Stash) transfer plugin. A dash (-) in this column means that no APs associated with this data had the capability to transfer files with the OSDF, whereas a zero (0) means that no OSDF file transfers occurred (though OSDF file transfers were possible)."
         custom_items["% OSDF Files"] = "Percent of all transferred files that were transferred using the OSDF plugin"
         custom_items["% OSDF Bytes"] = "Percent of all transferred bytes that were transferred using the OSDF plugin"
+        custom_items["Shadw Starts / Job Id"]   = "Num Shadw Starts per Num Uniq Job Ids"
+        custom_items["Exec Atts / Shadw Start"] = "Num Exec Atts per Num Shadw Starts"
+        custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
+
         custom_items["% Short Jobs"] = "Percent of Num Uniq Job Ids that were short jobs"
         custom_items["% Jobs w/>1 Exec Att"] = "Percent of Num Uniq Job Ids that had more than one execution attempt"
         custom_items["% Jobs w/1+ Holds"] = "Percent of Num Uniq Job Ids that had one or more jobs go on hold"
         custom_items["% Jobs Over Rqst Disk"] = "Percent of Num Uniq Job Ids that went over their requested disk space"
         custom_items["% Jobs using S'ty"] = "Percent of Num Uniq Job Ids that requested to run inside a Singularity image"
         custom_items["% Ckpt Able"] = "Percent of Num Uniq Job Ids that may be using user-level checkpointing"
-
-        custom_items["Shadw Starts / Job Id"]   = "Num Shadw Starts per Num Uniq Job Ids"
-        custom_items["Exec Atts / Shadw Start"] = "Num Exec Atts per Num Shadw Starts"
-        custom_items["Holds / Job Id"] = "Num Job Holds per Num Uniq Job Ids"
 
         custom_items["Mean Actv Hrs"] = "Mean slot activation time (in hours)"
         custom_items["Mean Setup Secs"] = "Mean slot activation setup time (in seconds). The slot activation setup time is the duration from when a shadow sends a claim activation to when the shadow is told that a job's executable is running."


### PR DESCRIPTION
In OSG CPU/GPU reports:

Move job health indicators earlier in the report for INF-1858

Move Resource Usage columns to end of report for INF-1859