### PR TITLE
INF-1856 Sort tables using arbitrary columns, make num jobs the sort column for most reports

### DIFF
--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -11,6 +11,7 @@ class BaseFilter:
     name = "job history"
 
     def __init__(self, skip_init=False, **kwargs):
+        self.sort_col = "All CPU Hours"
         self.logger = logging.getLogger("accounting.filter")
         if skip_init:
             return
@@ -303,11 +304,8 @@ class BaseFilter:
             # Store a tuple of all column data in order
             rows.append(tuple(row[col] for col in columns_sorted))
 
-        # Sort rows by All CPU Hours or All GPU Hours
-        try:
-            rows.sort(reverse=True, key=itemgetter(columns_sorted.index("All CPU Hours")))
-        except ValueError:
-            rows.sort(reverse=True, key=itemgetter(columns_sorted.index("All GPU Hours")))
+        # Sort rows
+        rows.sort(reverse=True, key=itemgetter(columns_sorted.index(self.sort_col)))
 
         # Ensure the TOTAL row is at the top
         try:

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -10,8 +10,8 @@ from accounting.pull_topology import get_site_map
 
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",
-    20: "Num Uniq Job Ids",
+    10: "Num Uniq Job Ids",
+    20: "All CPU Hours",
     30: "% Good CPU Hours",
 
     45: "% Ckpt Able",
@@ -122,6 +122,7 @@ class OsgScheddCpuFilter(BaseFilter):
         if kwargs.get("report_period") == "daily" and date.today().weekday() == 0:
             self.schedd_collector_host_map_checked = set()
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def schedd_collector_host(self, schedd):
         # Query Schedd ad in Collector for its CollectorHost,

--- a/accounting/filters/OsgScheddCpuHeldFilter.py
+++ b/accounting/filters/OsgScheddCpuHeldFilter.py
@@ -59,8 +59,8 @@ HOLD_REASONS = [
 ]
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",
-    20: "Num Uniq Job Ids",
+    10: "Num Uniq Job Ids",
+    20: "All CPU Hours",
 
     30: "Most Common Hold Reason",
     31: "% Holds Most Comm Reas",
@@ -141,6 +141,7 @@ class OsgScheddCpuHeldFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -15,8 +15,8 @@ from accounting.pull_topology import get_site_map
 MAX_INT = 2**62
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",
-    20: "Num Uniq Job Ids",
+    10: "Num Uniq Job Ids",
+    20: "All CPU Hours",
     30: "% Good CPU Hours",
 
     45: "% Ckpt Able",
@@ -86,6 +86,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def schedd_collector_host(self, schedd):
         # Query Schedd ad in Collector for its CollectorHost,
@@ -585,7 +586,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
             rows.append(tuple(row[col] for col in columns_sorted))
 
         # Sort rows by All CPU Hours
-        rows.sort(reverse=True, key=itemgetter(columns_sorted.index("All CPU Hours")))
+        rows.sort(reverse=True, key=itemgetter(columns_sorted.index(self.sort_col)))
 
         # Prepend the header row
         rows.insert(0, tuple(columns_sorted))

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -8,8 +8,8 @@ from .BaseFilter import BaseFilter
 
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",
-    20: "Num Uniq Job Ids",
+    10: "Num Uniq Job Ids",
+    20: "All CPU Hours",
     30: "CPU Hours / Exec Att",
 
     40: "% Jobs w/1+ Holds",
@@ -70,6 +70,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -8,7 +8,7 @@ from accounting.pull_hold_reasons import get_hold_reasons
 
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",  # Num Uniq Job Ids
+    10: "Num Uniq Job Ids",
     20: "Shadow Starts / Job Id",
     30: "Non Success Shadows (NSS)",
 
@@ -37,6 +37,7 @@ class OsgScheddCpuRetryFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
@@ -213,12 +214,6 @@ class OsgScheddCpuRetryFilter(BaseFilter):
             columns[5] = "Num Users"
         return columns
 
-    def merge_filtered_data(self, data, agg):
-        rows = super().merge_filtered_data(data, agg)
-        columns_sorted = list(rows[0])
-        columns_sorted[columns_sorted.index("All CPU Hours")] = "Num Uniq Job Ids"
-        rows[0] = tuple(columns_sorted)
-        return rows
 
     def compute_custom_columns(self, data, agg, agg_name):
 
@@ -296,7 +291,5 @@ class OsgScheddCpuRetryFilter(BaseFilter):
                 row["Most Used Schedd"] = "UNKNOWN"
         if agg == "Projects":
             row["Num Users"] = len(set(data["User"]))  
-
-        row["All CPU Hours"] = row["Num Uniq Job Ids"]
 
         return row 

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -10,9 +10,9 @@ from accounting.pull_topology import get_site_map
 
 
 DEFAULT_COLUMNS = {
-    10: "All CPU Hours",
-    15: "All GPU Hours",
-    20: "Num Uniq Job Ids",
+    10: "Num Uniq Job Ids",
+    20: "All CPU Hours",
+    25: "All GPU Hours",
     30: "% Good CPU Hours",
     35: "% Good GPU Hours",
 
@@ -115,6 +115,7 @@ class OsgScheddGpuFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Num Uniq Job Ids"
 
     def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs

--- a/accounting/filters/OsgScheddLongJobFilter.py
+++ b/accounting/filters/OsgScheddLongJobFilter.py
@@ -10,7 +10,7 @@ from .BaseFilter import BaseFilter
 
 DEFAULT_COLUMNS = {
     5 : "Project",
-    10: "All CPU Hours", # "Last Wall Hrs",
+    10: "Last Wall Hrs",
     20: "Total Wall Hrs",
     30: "Potent CPU Hrs",
     40: "Actual CPU Hrs",
@@ -78,6 +78,7 @@ class OsgScheddLongJobFilter(BaseFilter):
             except IOError:
                 pass
         super().__init__(**kwargs)
+        self.sort_col = "Last Wall Hrs"
 
     def get_query(self, index, start_ts, end_ts, **kwargs):
         # Returns dict matching Elasticsearch.search() kwargs
@@ -217,12 +218,6 @@ class OsgScheddLongJobFilter(BaseFilter):
         columns = DEFAULT_COLUMNS.copy()
         return columns
 
-    def merge_filtered_data(self, data, agg):
-        rows = super().merge_filtered_data(data, agg)
-        columns_sorted = list(rows[0])
-        columns_sorted[columns_sorted.index("All CPU Hours")] = "Last Wall Hrs"
-        rows[0] = tuple(columns_sorted)
-        return rows
 
     def compute_custom_columns(self, data, agg, agg_name):
         cpus_usage = data["CPUsUsage"][0]
@@ -264,7 +259,5 @@ class OsgScheddLongJobFilter(BaseFilter):
         row["Disk Used GB"] = data["DiskUsage"][0] / 1024**2
         row["MB Sent"] = data["BytesSent"][0] / 1024**2
         row["MB Recvd"] = data["BytesRecvd"][0] / 1024**2
-
-        row["All CPU Hours"] = row["Last Wall Hrs"]
 
         return row

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -114,8 +114,8 @@ class OsgScheddCpuFormatter(BaseFormatter):
 
     def get_legend(self):
         custom_items = OrderedDict()
-        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["Num Uniq Job Ids"] = "Number of unique job ids across all execution attempts"
+        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"

--- a/accounting/formatters/OsgScheddCpuHeldFormatter.py
+++ b/accounting/formatters/OsgScheddCpuHeldFormatter.py
@@ -150,8 +150,8 @@ class OsgScheddCpuHeldFormatter(BaseFormatter):
 
     def get_legend(self):
         custom_items = OrderedDict()
-        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["Num Uniq Job Ids"] = "Number of unique job ids across all execution attempts"
+        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"

--- a/accounting/formatters/OsgScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/OsgScheddCpuRemovedFormatter.py
@@ -80,8 +80,8 @@ class OsgScheddCpuRemovedFormatter(BaseFormatter):
 
     def get_legend(self):
         custom_items = OrderedDict()
-        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["Num Uniq Job Ids"] = "Number of unique job ids across all execution attempts"
+        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"

--- a/accounting/formatters/OsgScheddCpuRetryFormatter.py
+++ b/accounting/formatters/OsgScheddCpuRetryFormatter.py
@@ -53,8 +53,8 @@ class OsgScheddCpuRetryFormatter(BaseFormatter):
 
     def get_legend(self):
         custom_items = OrderedDict()
-        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["Num Uniq Job Ids"] = "Number of unique job ids across all execution attempts"
+        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"

--- a/accounting/formatters/OsgScheddGpuFormatter.py
+++ b/accounting/formatters/OsgScheddGpuFormatter.py
@@ -117,8 +117,8 @@ class OsgScheddGpuFormatter(BaseFormatter):
 
     def get_legend(self):
         custom_items = OrderedDict()
-        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["Num Uniq Job Ids"] = "Number of unique job ids across all execution attempts"
+        custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"


### PR DESCRIPTION
Now we're able to set `self.sort_col` in a filter class to set the column to sort the tables by. Still need some `merge_filtered_data()` override hackery to adjust the column names per table, but removes most of the need to override that method.

Starting off with just adjusting the OSPool reports. We should notify the RCFs before merging this so they're not caught off guard by the change in the sorting.