### PR TITLE
INF-1917 Report on all CHTC APs in usage reports

### DIFF
--- a/accounting/filters/ChtcScheddCpuFilter.py
+++ b/accounting/filters/ChtcScheddCpuFilter.py
@@ -105,7 +105,7 @@ class ChtcScheddCpuFilter(BaseFilter):
                                 }
                             }},
                             {"regexp": {
-                                "ScheddName.keyword": "(submit-?[0-9]+|learn|ap[0-9]+)[.]chtc[.]wisc[.]edu"
+                                "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
                         ]
                     }

--- a/accounting/filters/ChtcScheddCpuMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuMonthlyFilter.py
@@ -75,7 +75,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
                                 }
                             }},
                             {"regexp": {
-                                "ScheddName.keyword": "(submit-?[0-9]+|learn|ap[0-9]+)[.]chtc[.]wisc[.]edu"
+                                "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
                         ]
                     }

--- a/accounting/filters/ChtcScheddCpuRemovedFilter.py
+++ b/accounting/filters/ChtcScheddCpuRemovedFilter.py
@@ -72,7 +72,7 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
                                 "JobStatus": 3
                             }},
                             {"regexp": {
-                                "ScheddName.keyword": "(submit-?[0-9]+|learn|ap[0-9]+)[.]chtc[.]wisc[.]edu"
+                                "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
                         ]
                     }

--- a/accounting/formatters/ChtcScheddCpuFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuFormatter.py
@@ -36,12 +36,12 @@ class ChtcScheddCpuFormatter(BaseFormatter):
         start = datetime.fromtimestamp(start_ts)
         if report_period in ["daily", "weekly", "monthly"]:
             start_date = start.strftime("%Y-%m-%d")
-            subject_str = f"CHTC Schedd {report_period.capitalize()} Usage Report {start_date}"
+            subject_str = f"CHTC AP {report_period.capitalize()} Usage Report {start_date}"
         else:
             end = datetime.fromtimestamp(end_ts)
             start_date = start.strftime("%Y-%m-%d %H:%M:%S")
             end_date = end.strftime("%Y-%m-%d %H:%M:%S")
-            subject_str = f"CHTC Schedd Usage Report {start_date} to {end_date}"
+            subject_str = f"CHTC AP Usage Report {start_date} to {end_date}"
         return subject_str
 
     def rm_cols(self, data):

--- a/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
@@ -36,12 +36,12 @@ class ChtcScheddCpuRemovedFormatter(BaseFormatter):
         start = datetime.fromtimestamp(start_ts)
         if report_period in ["daily", "weekly", "monthly"]:
             start_date = start.strftime("%Y-%m-%d")
-            subject_str = f"CHTC Schedd {report_period.capitalize()} Removed Jobs Report {start_date}"
+            subject_str = f"CHTC AP {report_period.capitalize()} Removed Jobs Report {start_date}"
         else:
             end = datetime.fromtimestamp(end_ts)
             start_date = start.strftime("%Y-%m-%d %H:%M:%S")
             end_date = end.strftime("%Y-%m-%d %H:%M:%S")
-            subject_str = f"CHTC Schedd Removed Jobs Report {start_date} to {end_date}"
+            subject_str = f"CHTC AP Removed Jobs Report {start_date} to {end_date}"
         return subject_str
 
     def rm_cols(self, data):

--- a/accounting/formatters/ChtcScheddGpuFormatter.py
+++ b/accounting/formatters/ChtcScheddGpuFormatter.py
@@ -36,12 +36,12 @@ class ChtcScheddGpuFormatter(BaseFormatter):
         start = datetime.fromtimestamp(start_ts)
         if report_period in ["daily", "weekly", "monthly"]:
             start_date = start.strftime("%Y-%m-%d")
-            subject_str = f"CHTC GPUs Schedd {report_period.capitalize()} Usage Report {start_date}"
+            subject_str = f"CHTC GPUs {report_period.capitalize()} Usage Report {start_date}"
         else:
             end = datetime.fromtimestamp(end_ts)
             start_date = start.strftime("%Y-%m-%d %H:%M:%S")
             end_date = end.strftime("%Y-%m-%d %H:%M:%S")
-            subject_str = f"CHTC GPUs Schedd Usage Report {start_date} to {end_date}"
+            subject_str = f"CHTC GPUs Usage Report {start_date} to {end_date}"
         return subject_str
 
     def rm_cols(self, data):


### PR DESCRIPTION
Before, the list of APs whose jobs we reported on was limited to the main, non-researcher dedicated APs. It has instead been requested that we report on all CHTC APs, regardless of purpose.

Also cleaned up a long-standing naming issue Schedd -> AP.