### PR TITLE
Fix for possible absent CondorVersion field in Osg report

### DIFF
--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -840,10 +840,10 @@ class OsgScheddCpuFilter(BaseFilter):
 
         if osdf_files_count == 0 or osdf_bytes_total == 0:
             condor_versions_set = set(data["CondorVersion"])
+            condor_versions_set.discard(None)
             condor_versions_tuples_list = []
             for version in condor_versions_set:
-                if not version is None:
-                    condor_versions_tuples_list.append(tuple([int(x) for x in version.split()[1].split(".")]))
+                condor_versions_tuples_list.append(tuple([int(x) for x in version.split()[1].split(".")]))
             if all(condor_version_tuple < (9, 7, 0) for condor_version_tuple in condor_versions_tuples_list):
                 row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = "-"
             else:

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -842,7 +842,8 @@ class OsgScheddCpuFilter(BaseFilter):
             condor_versions_set = set(data["CondorVersion"])
             condor_versions_tuples_list = []
             for version in condor_versions_set:
-                condor_versions_tuples_list.append(tuple([int(x) for x in version.split()[1].split(".")]))
+                if not version is None:
+                    condor_versions_tuples_list.append(tuple([int(x) for x in version.split()[1].split(".")]))
             if all(condor_version_tuple < (9, 7, 0) for condor_version_tuple in condor_versions_tuples_list):
                 row["OSDF Files Xferd"] = row["% OSDF Files"] = row["% OSDF Bytes"] = "-"
             else:


### PR DESCRIPTION
Some CHTC and OSG job Ads don't have a `CondorVersion` field, causing the version check for whether osdf transfer data is zero or non-reporting to fail by trying to envoke `.split()` on `None`. This fix will also go into the CHTC report when I finish homogenizing it with the OSG report.