### PR TITLE
INF-1954 Add job unit columns to CHTC and OSPool reports

### DIFF
--- a/accounting/formatters/ChtcScheddCpuFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuFormatter.py
@@ -105,6 +105,8 @@ class ChtcScheddCpuFormatter(BaseFormatter):
             "Output MB / File":       lambda x: f"<td>{float(x):.1f}</td>",
             "Max Rqst Disk GB":       lambda x: f"<td>{float(x):.1f}</td>",
             "Max Used Disk GB":       lambda x: f"<td>{float(x):.1f}</td>",
+            "Med Job Units":          lambda x: f"<td>{float(x):.1f}</td>",
+            "Max Job Units":          lambda x: f"<td>{float(x):.1f}</td>",
         }
         rows = super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
         return rows
@@ -115,6 +117,10 @@ class ChtcScheddCpuFormatter(BaseFormatter):
         custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
+        custom_items["Job Units"]        = "The minimum number of base job units required to satisfy a job's resource requirements. The base job unit is 1 CPU, 4 GB memory, and 4 GB disk"
+        custom_items["Job Unit Hours"]   = """Job units multiplied by total wallclock hours, like "All CPU Hours" but using "Job Units" instead of CPUs"""
+        custom_items["Med Job Units"]    = "Median number of job units requested by the submitted jobs"
+        custom_items["Med Job Units"]    = "Maximum number of job units requested by a submitted job"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"
         custom_items["Max Used Mem MB"]  = "Maximum measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst Cpus"]    = "Maximum number of CPUs requested across all submitted jobs"

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -109,6 +109,8 @@ class OsgScheddCpuFormatter(BaseFormatter):
             "Output MB / File":       lambda x: f"<td>{float(x):.1f}</td>",
             "Max Rqst Disk GB":       lambda x: f"<td>{float(x):.1f}</td>",
             "Max Used Disk GB":       lambda x: f"<td>{float(x):.1f}</td>",
+            "Med Job Units":          lambda x: f"<td>{float(x):.1f}</td>",
+            "Max Job Units":          lambda x: f"<td>{float(x):.1f}</td>",
         }
         return super().format_rows(header, rows, custom_fmts=custom_fmts, default_text_fmt=default_text_fmt, default_numeric_fmt=default_numeric_fmt)
 
@@ -118,6 +120,10 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["All CPU Hours"]    = "Total CPU hours for all execution attempts, including preemption and removal"
         custom_items["% Good CPU Hours"] = "Good CPU Hours per All CPU Hours, as a percentage"
         custom_items["Good CPU Hours"]   = "Total CPU hours for execution attempts that ran to completion"
+        custom_items["Job Units"]        = "The minimum number of base job units required to satisfy a job's resource requirements. The base job unit is 1 CPU, 4 GB memory, and 4 GB disk"
+        custom_items["Job Unit Hours"]   = """Job units multiplied by total wallclock hours, like "All CPU Hours" but using "Job Units" instead of CPUs"""
+        custom_items["Med Job Units"]    = "Median number of job units requested by the submitted jobs"
+        custom_items["Med Job Units"]    = "Maximum number of job units requested by a submitted job"
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"
         custom_items["Max Used Mem MB"]  = "Maximum measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst Cpus"]    = "Maximum number of CPUs requested across all submitted jobs"

--- a/accounting/functions.py
+++ b/accounting/functions.py
@@ -169,3 +169,17 @@ def send_email(subject, from_addr, to_addrs, cc_addrs, bcc_addrs, reply_to_addr,
 
         else:
             logger.error(f"Failed to send email after {tries} loops")
+
+
+def get_job_units(cpus, memory_gb, disk_gb):
+    unit_size = {
+        "cpus": 1,
+        "memory_gb": 4,
+        "disk_gb": 4,
+    }
+    job_units = max([
+        max(1., cpus/unit_size["cpus"]),
+        max(1., memory_gb/unit_size["memory_gb"]),
+        max(1., disk_gb/unit_size["disk_gb"])
+    ])
+    return job_units


### PR DESCRIPTION
A basic job unit is defined as:
1 CPU
4 GB Memory
4 GB Disk

The number of job units that a job requests are the minimum number of units that are required to fulfill the request. For example, a job requesting 2 CPUs, 6 GB Memory, and 5 GB Disk would take up 2.0 units due to the CPU request. If that job requested 10 GB Memory instead, it would be 2.5 job units large.

The highlighted metric in this case is job unit hours, which is the number of job units times the total wallclock time, similar to CPU hours.