### PR TITLE
INF-1594 Push daily totals to Tiger ES

### DIFF
--- a/accounting/push_totals_to_es.py
+++ b/accounting/push_totals_to_es.py
@@ -57,6 +57,9 @@ def push_totals_to_es(csv_files, index_name, **kwargs):
         else:
             es_client["http_auth"] = (es_user, es_pass)
 
+        if "es_url_prefix" in kwargs:
+            es_client["url_prefix"] = kwargs["es_url_prefix"]
+
         # Only use HTTPS if CA certs are given or if certifi is available
         if es_use_https:
             if es_ca_certs is not None:

--- a/send_email.py
+++ b/send_email.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import time
+import json
 import pickle
 import logging
 import logging.handlers
@@ -108,3 +109,14 @@ if args.report_period in ["daily", "weekly", "monthly"] and not args.do_not_uplo
         logger.error("Could not push daily totals to Elasticsearch")
         if args.debug:
             logger.exception("Error follows")
+
+    # Push summary data to tables in Tiger
+    if Path("tiger-es-summary-config.json").exists():
+        logger.info("Pushing daily totals to Tiger Elasticsearch")
+        try:
+            tiger_args = json.load(Path("tiger-es-summary-config.json").open("r"))
+            push_totals_to_es(table_files, "usage-summary-000001", **tiger_args)
+        except Exception as e:
+            logger.error("Could not push daily totals to Tiger Elasticsearch")
+            if args.debug:
+                logger.exception("Error follows")


### PR DESCRIPTION
We don't want to open up the entire job classad database for public reads, but having the top-line totals from each day/week/month report is fine (and something we report on anyway). This code pushes data to an index that is read-only by the "default" user in the Tiger Elasticsearch instance.

The code added here is only enabled by having a JSON file containing the Elasticsearch connection info in a file named `tiger-es-summary-config.json`. I have provided this file for the `chtc_auto` user on `accounting3000`.