### PR TITLE
INF-2488 Use actual cluster's institution for jobs that run on PRP

### DIFF
--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -7,7 +7,7 @@ from datetime import date
 from pathlib import Path
 from .BaseFilter import BaseFilter
 from accounting.pull_topology import get_site_map
-from accounting.functions import get_job_units, get_topology_project_data
+from accounting.functions import get_job_units, get_topology_project_data, get_prp_mapping_data
 
 
 DEFAULT_COLUMNS = {
@@ -107,6 +107,7 @@ DEFAULT_FILTER_ATTRS = [
 
 
 SITE_MAP = get_site_map()
+PRP_ID_MAP = get_prp_mapping_data()
 
 
 class OsgScheddCpuFilter(BaseFilter):
@@ -428,6 +429,9 @@ class OsgScheddCpuFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
+        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+            osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
+            institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:
             institution = SITE_MAP.get(site, f"Unmapped resource: {site}")
         o = data["Institution"][institution]

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -429,7 +429,7 @@ class OsgScheddCpuFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
-        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+        elif "MachineAttrOSG_INSTITUTION_ID0" in i:
             osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
             institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -11,7 +11,7 @@ import elasticsearch.helpers
 from functools import lru_cache
 from .BaseFilter import BaseFilter
 from accounting.pull_topology import get_site_map
-from accounting.functions import get_job_units, get_topology_project_data
+from accounting.functions import get_job_units, get_topology_project_data, get_prp_mapping_data
 
 MAX_INT = 2**62
 
@@ -368,6 +368,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
+        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+            osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
+            institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:
             institution = SITE_MAP.get(site, f"Unmapped resource: {site}")
         output = data["Institution"][institution]

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -368,7 +368,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
-        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+        elif "MachineAttrOSG_INSTITUTION_ID0" in i:
             osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
             institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -7,6 +7,7 @@ from datetime import date
 from pathlib import Path
 from .BaseFilter import BaseFilter
 from accounting.pull_topology import get_site_map
+from accounting.functions import get_prp_mapping_data
 
 
 DEFAULT_COLUMNS = {
@@ -394,6 +395,9 @@ class OsgScheddGpuFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
+        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+            osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
+            institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:
             institution = SITE_MAP.get(site, f"Unmapped resource: {site}")
         o = data["Institution"][institution]

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -395,7 +395,7 @@ class OsgScheddGpuFilter(BaseFilter):
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
             institution = "Unknown (resource name missing)"
-        elif site.lower() == "SDSC-PRP-OSPool-Provisioner".lower() and "MachineAttrOSG_INSTITUTION_ID0" in i:
+        elif "MachineAttrOSG_INSTITUTION_ID0" in i:
             osg_id_short = (i.get("MachineAttrOSG_INSTITUTION_ID0") or "").split("_")[-1]
             institution = PRP_ID_MAP.get(osg_id_short, SITE_MAP.get(site, f"Unmapped resource: {site}"))
         else:

--- a/accounting/functions.py
+++ b/accounting/functions.py
@@ -346,7 +346,7 @@ def get_prp_mapping_data(
                         osg_id = resource.get("id")
                         if not osg_id:
                             continue
-                        institution = osg_id_institution_map.get(osg_id)
+                        institution = osg_id_institution_map.get(osg_id, resource.get("name"))
                         if not institution:
                             continue
                         osg_id_short = osg_id.split("/")[-1]


### PR DESCRIPTION
Added a function that maps the "short IDs" (last part of the OSG and/or ROR IDs) to institution names, then use that function to determine the institution if a job ran on SDSC-PRP.