### PR TITLE
INF-2805 Remove local/scheduler universe usage

### DIFF
--- a/accounting/filters/BaseFilter.py
+++ b/accounting/filters/BaseFilter.py
@@ -79,11 +79,20 @@ class BaseFilter:
             "track_scores": False,
             "body": {
                 "query": {
-                    "range": {
-                        "RecordTime": {
-                            "gte": start_ts,
-                            "lt": end_ts,
-                        }
+                    "bool": {
+                        "filter": [
+                            {"range": {
+                                "RecordTime": {
+                                   "gte": start_ts,
+                                    "lt": end_ts,
+                                }
+                            }},
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }

--- a/accounting/filters/ChtcScheddCpuFilter.py
+++ b/accounting/filters/ChtcScheddCpuFilter.py
@@ -57,8 +57,6 @@ DEFAULT_COLUMNS = {
     355: "Num Jobs w/1+ Holds",
     357: "Num Jobs Over Rqst Disk",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
 
@@ -87,7 +85,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -132,7 +129,12 @@ class ChtcScheddCpuFilter(BaseFilter):
                             {"regexp": {
                                 "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -152,7 +154,7 @@ class ChtcScheddCpuFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -160,31 +162,22 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -194,7 +187,7 @@ class ChtcScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -227,7 +220,7 @@ class ChtcScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -235,31 +228,22 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -269,7 +253,7 @@ class ChtcScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -306,7 +290,7 @@ class ChtcScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -314,31 +298,22 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -348,7 +323,7 @@ class ChtcScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -423,19 +398,13 @@ class ChtcScheddCpuFilter(BaseFilter):
             else:
                 total_cpu_time.append(total_time * cpus)
 
-        # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -458,15 +427,14 @@ class ChtcScheddCpuFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, last_wallclock_time, committed_time, no_shadow, job_status) in zip(
+        for (is_short, last_wallclock_time, committed_time, job_status) in zip(
                 is_short_job,
                 data["lastremotewallclocktime"],
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
             #goodput_time = last_wallclock_time or committed_time
             goodput_time = committed_time
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -482,7 +450,6 @@ class ChtcScheddCpuFilter(BaseFilter):
         osdf_bytes_total = 0
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -490,20 +457,12 @@ class ChtcScheddCpuFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["transferinputstats"],
                 data["BytesRecvd"],
                 data["transferoutputstats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -606,8 +565,6 @@ class ChtcScheddCpuFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"] = sum(data["_NumCkptJobs"])
         row["Num S'ty Jobs"]    = len(self.clean(data["SingularityImage"]))
 

--- a/accounting/filters/ChtcScheddCpuMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuMonthlyFilter.py
@@ -56,8 +56,6 @@ DEFAULT_COLUMNS = {
     355: "Num Jobs w/1+ Holds",
     357: "Num Jobs Over Rqst Disk",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
 
@@ -96,7 +94,12 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
                             {"regexp": {
                                 "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -106,10 +109,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
     def reduce_data(self, i, o, t, is_site=False):
 
         is_removed = i.get("JobStatus") == 3
-        is_scheduler = i.get("JobUniverse") == 7
-        is_local = i.get("JobUniverse") == 12
-        has_shadow = not (is_scheduler or is_local)
-        is_dagnode = i.get("DAGNodeName") is not None and i.get("JobUniverse", 5) != 12
+        is_dagnode = i.get("DAGNodeName") is not None
         is_exec = i.get("NumJobStarts", 0) >= 1
         is_multiexec = i.get("NumJobStarts", 0) > 1
         has_holds = i.get("NumHolds", 0) > 0
@@ -132,7 +132,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         osdf_files = 0
         osdf_bytes = 0
         job_units = 0
-        if has_shadow and not is_removed:
+        if not is_removed:
             goodput_time = int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
             if goodput_time > 0 and goodput_time < 60:
                 is_short = True
@@ -145,19 +145,18 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
                 is_long = True
         elif not is_removed:
             goodput_time = int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
-        if has_shadow:
-            job_units = get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
-            )
+        job_units = get_job_units(
+            cpus=i.get("RequestCpus", 1),
+            memory_gb=i.get("RequestMemory", 1024)/1024,
+            disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+        )
         input_files = 0
         input_bytes = 0
         output_files = 0
         output_bytes = 0
         got_cedar_input_bytes = False
         got_cedar_output_bytes = False
-        if has_shadow and not is_site:
+        if not is_site:
             is_ckptable = ((
                     i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
                     i.get("Is_resumable", False)
@@ -212,13 +211,10 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         sum_cols["Jobs"] = 1
         sum_cols["RunJobs"] = int(is_exec)
         sum_cols["RmJobs"] = int(is_removed)
-        sum_cols["SchedulerJobs"] = int(is_scheduler)
-        sum_cols["LocalJobs"] = int(is_local)
         sum_cols["DAGNodeJobs"] = int(is_dagnode)
         sum_cols["MultiExecJobs"] = int(is_multiexec)
         sum_cols["ShortJobs"] = int(is_short)
         sum_cols["LongJobs"] = int(is_long)
-        sum_cols["ShadowJobs"] = int(has_shadow)
         sum_cols["Checkpointable"] = int(is_ckptable)
         sum_cols["JobsOverRqstDisk"] = int(is_over_rqst_disk)
         sum_cols["SingularityJobs"] = int(is_singularity_job)
@@ -232,9 +228,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(i.get("RequestCpus", 1), 1))
         sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(i.get("RequestCpus", 1), 1))
         sum_cols["JobUnitTime"] = job_units * i.get("RemoteWallClockTime", 0)
-        sum_cols["NumShadowStarts"] = int(has_shadow) * i.get("NumShadowStarts", 0)
-        sum_cols["NumJobStarts"] = int(has_shadow) * i.get("NumJobStarts", 0)
-        sum_cols["NumBadJobStarts"] = int(has_shadow) * max(i.get("NumJobStarts", 0) - 1, 0)
+        sum_cols["NumShadowStarts"] = i.get("NumShadowStarts", 0)
+        sum_cols["NumJobStarts"] = i.get("NumJobStarts", 0)
+        sum_cols["NumBadJobStarts"] = max(i.get("NumJobStarts", 0) - 1, 0)
         sum_cols["HeldJobs"] = int(has_holds)
         sum_cols["NumJobHolds"] = i.get("NumHolds", 0)
 
@@ -379,8 +375,6 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         row["Num Exec Atts"]       = data["NumJobStarts"]
         row["Num Shadw Starts"]    = data["NumShadowStarts"]
         row["Num Job Holds"]       = data["NumJobHolds"]
-        row["Num Local Univ Jobs"] = data["LocalJobs"]
-        row["Num Sched Univ Jobs"] = data["SchedulerJobs"]
         row["Num Ckpt Able Jobs"]  = data["Checkpointable"]
         row["Num S'ty Jobs"]       = data["SingularityJobs"]
 
@@ -388,8 +382,8 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
             row["Input Files / Exec Att"] = data["InputFiles"] / data["NumJobStarts"]
         else:
             row["Input Files / Exec Att"] = ""
-        if data["ShadowJobs"] > 0 and data.get("OutputFiles") is not None:
-            row["Output Files / Job"] = data["OutputFiles"] / data["ShadowJobs"]
+        if data["Jobs"] > 0 and data.get("OutputFiles") is not None:
+            row["Output Files / Job"] = data["OutputFiles"] / data["Jobs"]
         else:
             row["Output Files / Job"] = ""
 

--- a/accounting/filters/ChtcScheddCpuOspoolFilter.py
+++ b/accounting/filters/ChtcScheddCpuOspoolFilter.py
@@ -61,8 +61,6 @@ DEFAULT_COLUMNS = {
     355: "Num Jobs w/1+ Holds",
     357: "Num Jobs Over Rqst Disk",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
 
@@ -91,7 +89,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -217,7 +214,12 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
                             {"regexp": {
                                 "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -241,7 +243,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -249,31 +251,22 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -283,7 +276,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -320,7 +313,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -328,31 +321,23 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
 
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -362,7 +347,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -403,7 +388,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -411,31 +396,22 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -445,7 +421,7 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -523,16 +499,11 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -555,15 +526,14 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, last_wallclock_time, committed_time, no_shadow, job_status) in zip(
+        for (is_short, last_wallclock_time, committed_time, job_status) in zip(
                 is_short_job,
                 data["lastremotewallclocktime"],
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
             #goodput_time = last_wallclock_time or committed_time
             goodput_time = committed_time
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -579,7 +549,6 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         osdf_bytes_total = 0
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -587,20 +556,12 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["transferinputstats"],
                 data["BytesRecvd"],
                 data["transferoutputstats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -703,8 +664,6 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"] = sum(data["_NumCkptJobs"])
         row["Num S'ty Jobs"]    = len(self.clean(data["SingularityImage"]))
 

--- a/accounting/filters/ChtcScheddDSIGpuFilter.py
+++ b/accounting/filters/ChtcScheddDSIGpuFilter.py
@@ -63,13 +63,15 @@ class ChtcScheddDSIGpuFilter(BaseFilter):
                             {"term": {
                                 "JobStatus": 4
                             }},
-                            {"term": {
-                                "JobUniverse": 5
-                            }},
                             {"regexp": {
                                 "LastRemoteHost.keyword": ".*dsigpu-?[0-9]+[.]chtc[.]wisc[.]edu"
                             }},
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }

--- a/accounting/filters/ChtcScheddGpuFilter.py
+++ b/accounting/filters/ChtcScheddGpuFilter.py
@@ -81,7 +81,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -128,7 +127,12 @@ class ChtcScheddGpuFilter(BaseFilter):
                                     "gt": 0
                                 }
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -148,7 +152,7 @@ class ChtcScheddGpuFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -156,26 +160,20 @@ class ChtcScheddGpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -204,7 +202,7 @@ class ChtcScheddGpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -212,26 +210,20 @@ class ChtcScheddGpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -265,7 +257,7 @@ class ChtcScheddGpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -273,31 +265,22 @@ class ChtcScheddGpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -324,10 +307,6 @@ class ChtcScheddGpuFilter(BaseFilter):
 
         # Filter out jobs that were removed
         if i.get("JobStatus", 4) == 3:
-            return
-
-        # Filter out scheduler and local universe jobs
-        if i.get("JobUniverse") in [7, 12]:
             return
 
         # Get output dict for this site
@@ -429,16 +408,11 @@ class ChtcScheddGpuFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -458,12 +432,11 @@ class ChtcScheddGpuFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, goodput_time, no_shadow, job_status) in zip(
+        for (is_short, goodput_time, job_status) in zip(
                 is_short_job,
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -479,7 +452,6 @@ class ChtcScheddGpuFilter(BaseFilter):
         osdf_bytes_total = 0
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -487,20 +459,12 @@ class ChtcScheddGpuFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["transferinputstats"],
                 data["BytesRecvd"],
                 data["transferoutputstats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -606,8 +570,6 @@ class ChtcScheddGpuFilter(BaseFilter):
         row["Max Rqst Gpus"]    = max(self.clean(data["RequestGpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"]  = sum(data["_NumCkptJobs"])
         row["Num S'ty Jobs"]       = len(self.clean(data["SingularityImage"]))
 

--- a/accounting/filters/IgwnScheddCpuFilter.py
+++ b/accounting/filters/IgwnScheddCpuFilter.py
@@ -57,8 +57,6 @@ DEFAULT_COLUMNS = {
     355: "Num Jobs w/1+ Holds",
     357: "Num Jobs Over Rqst Disk",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
 
@@ -87,7 +85,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -134,6 +131,9 @@ class IgwnScheddCpuFilter(BaseFilter):
                             {"term": {
                                 "MATCH_EXP_JOB_GLIDEIN_Site.keyword": "Unknown"
                             }},
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
                         ],
                     }
                 }
@@ -154,7 +154,7 @@ class IgwnScheddCpuFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -162,31 +162,22 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -196,7 +187,7 @@ class IgwnScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -229,7 +220,7 @@ class IgwnScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -237,31 +228,22 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -271,7 +253,7 @@ class IgwnScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -308,7 +290,7 @@ class IgwnScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -316,31 +298,22 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -350,7 +323,7 @@ class IgwnScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -427,16 +400,11 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -459,15 +427,14 @@ class IgwnScheddCpuFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, last_wallclock_time, committed_time, no_shadow, job_status) in zip(
+        for (is_short, last_wallclock_time, committed_time, job_status) in zip(
                 is_short_job,
                 data["lastremotewallclocktime"],
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
             #goodput_time = last_wallclock_time or committed_time
             goodput_time = committed_time
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -483,7 +450,6 @@ class IgwnScheddCpuFilter(BaseFilter):
         osdf_bytes_total = 0
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -491,20 +457,12 @@ class IgwnScheddCpuFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["transferinputstats"],
                 data["BytesRecvd"],
                 data["transferoutputstats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -607,8 +565,6 @@ class IgwnScheddCpuFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"] = sum(data["_NumCkptJobs"])
         row["Num S'ty Jobs"]    = len(self.clean(data["SingularityImage"]))
 

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -62,8 +62,6 @@ DEFAULT_COLUMNS = {
     355: "Num Jobs w/1+ Holds",
     357: "Num Jobs Over Rqst Disk",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
     400: "Num S'ty Jobs",
 
@@ -92,7 +90,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -217,7 +214,7 @@ class OsgScheddCpuFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -225,14 +222,8 @@ class OsgScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
+        if  (
                 i.get("SuccessCheckpointExitBySignal", False) or
                 i.get("SuccessCheckpointExitCode") is not None
             ):
@@ -242,7 +233,6 @@ class OsgScheddCpuFilter(BaseFilter):
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -254,7 +244,7 @@ class OsgScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -285,7 +275,7 @@ class OsgScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -293,14 +283,8 @@ class OsgScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
+        if  (
                 i.get("SuccessCheckpointExitBySignal", False) or
                 i.get("SuccessCheckpointExitCode") is not None
             ):
@@ -310,7 +294,6 @@ class OsgScheddCpuFilter(BaseFilter):
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -322,7 +305,7 @@ class OsgScheddCpuFilter(BaseFilter):
             o["_NumBadJobStarts"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -357,7 +340,7 @@ class OsgScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -365,14 +348,8 @@ class OsgScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
+        if  (
                 i.get("SuccessCheckpointExitBySignal", False) or
                 i.get("SuccessCheckpointExitCode") is not None
             ):
@@ -381,7 +358,7 @@ class OsgScheddCpuFilter(BaseFilter):
             o["_NumCkptJobs"].append(0)
 
         # Compute job units
-        if univ not in (7, 12) and i.get("RemoteWallClockTime", 0) > 0:
+        if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
                 cpus=i.get("RequestCpus", 1),
                 memory_gb=i.get("RequestMemory", 1024)/1024,
@@ -392,7 +369,6 @@ class OsgScheddCpuFilter(BaseFilter):
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -421,10 +397,6 @@ class OsgScheddCpuFilter(BaseFilter):
         if i.get("JobStatus", 4) == 3:
             return
 
-        # Filter out scheduler and local universe jobs
-        if i.get("JobUniverse") in [7, 12]:
-            return
-
         # Get output dict for this institution
         site = i.get("MachineAttrGLIDEIN_ResourceName0", i.get("MATCH_EXP_JOBGLIDEIN_ResourceName"))
         if (site is None) or (not site):
@@ -442,7 +414,7 @@ class OsgScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -486,7 +458,7 @@ class OsgScheddCpuFilter(BaseFilter):
         if agg == "Institution":
             columns[4] = "Num Sites"
             columns[5] = "Num Users"
-            rm_columns = [30,45,50,51,52,53,54,55,56,57,70,80,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,370,380,390]
+            rm_columns = [30,45,50,51,52,53,54,55,56,57,70,80,180,181,182,190,191,192,300,305,310,320,325,330,340,350,355,390]
             [columns.pop(key) for key in rm_columns if key in columns]
         return columns
 
@@ -667,16 +639,11 @@ class OsgScheddCpuFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -696,12 +663,11 @@ class OsgScheddCpuFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, goodput_time, no_shadow, job_status) in zip(
+        for (is_short, goodput_time, job_status) in zip(
                 is_short_job,
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -717,7 +683,6 @@ class OsgScheddCpuFilter(BaseFilter):
         osdf_bytes_total = 0
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -725,20 +690,12 @@ class OsgScheddCpuFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["TransferInputStats"],
                 data["BytesRecvd"],
                 data["TransferOutputStats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -827,8 +784,6 @@ class OsgScheddCpuFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"]  = sum(data["_NumCkptJobs"])
         row["Num S'ty Jobs"]       = len(self.clean(data["SingularityImage"]))
 

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -33,8 +33,6 @@ DEFAULT_COLUMNS = {
     320: "Num Shadw Starts",
     325: "Num Job Holds",
     330: "Num DAG Node Jobs",
-    340: "Num Local Univ Jobs",
-    350: "Num Sched Univ Jobs",
 }
 
 
@@ -49,7 +47,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -91,7 +88,12 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
                             {"term": {
                                 "JobStatus": 3
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -169,7 +171,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -177,15 +179,8 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 0 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -226,7 +221,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -234,15 +229,8 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 0 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -287,7 +275,7 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -295,15 +283,8 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 0 and
                 i.get("RemoteWallClockTime", 0) > 0 and
                 i.get("RemoteWallClockTime") != i.get("CommittedTime")
@@ -372,16 +353,11 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -401,12 +377,11 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, goodput_time, no_shadow, job_status) in zip(
+        for (is_short, goodput_time, job_status) in zip(
                 is_short_job,
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -430,8 +405,6 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
 
         # Compute derivative columns
         if row["Num Uniq Job Ids"] - row["Rm'd Jobs w/o Shadw Start"] > 0:

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -26,7 +26,7 @@ DEFAULT_FILTER_ATTRS = [
 
 class OsgScheddCpuRetryFilter(BaseFilter):
     name = "OSG schedd retried job history"
-    
+
     def __init__(self, **kwargs):
         self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}
         self.schedd_collector_host_map_pickle = Path("ospool-host-map.pkl")
@@ -60,10 +60,12 @@ class OsgScheddCpuRetryFilter(BaseFilter):
                                     "gt": 0,
                                 }
                             }},
-                            {"term": {
-                                "JobUniverse": 5,
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
                             }},
-                        ]
+                        ],
                     }
                 }
             }
@@ -129,7 +131,7 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
 
-        # Filter out jobs that did not run in the OS pool        
+        # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i):
             return
 
@@ -290,6 +292,6 @@ class OsgScheddCpuRetryFilter(BaseFilter):
             else:
                 row["Most Used Schedd"] = "UNKNOWN"
         if agg == "Projects":
-            row["Num Users"] = len(set(data["User"]))  
+            row["Num Users"] = len(set(data["User"]))
 
-        return row 
+        return row

--- a/accounting/filters/OsgScheddJobDistroFilter.py
+++ b/accounting/filters/OsgScheddJobDistroFilter.py
@@ -67,15 +67,15 @@ class OsgScheddJobDistroFilter(BaseFilter):
                                     "lt": end_ts,
                                 }
                             }},
-                            {"term": {
-                                "JobUniverse": {
-                                    "value": 5,
-                                }
-                            }},
                             {"terms": {
                                 "ScheddName.keyword": list(OSG_CONNECT_APS)
                             }},
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -126,7 +126,6 @@ class OsgScheddJobDistroFilter(BaseFilter):
 
     @lru_cache(maxsize=1024)
     def is_ospool_job(self, schedd_name, last_remote_pool):
-        remote_pool = set()
         if last_remote_pool is not None:
             if last_remote_pool.strip():
                 return last_remote_pool in self.collector_hosts

--- a/accounting/filters/OsgScheddLongJobFilter.py
+++ b/accounting/filters/OsgScheddLongJobFilter.py
@@ -100,12 +100,12 @@ class OsgScheddLongJobFilter(BaseFilter):
                                     "gt": 3*60*60
                                 }
                             }},
-                            {"term": {
-                                "JobUniverse": {
-                                "value": 5,
-                                }
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
                             }},
-                        ]
+                        ],
                     }
                 }
             }

--- a/accounting/filters/PathScheddCpuFilter.py
+++ b/accounting/filters/PathScheddCpuFilter.py
@@ -50,8 +50,6 @@ DEFAULT_COLUMNS = {
     350: "Num Jobs w/>1 Exec Att",
     355: "Num Jobs w/1+ Holds",
     360: "Num Short Jobs",
-    370: "Num Local Univ Jobs",
-    380: "Num Sched Univ Jobs",
     390: "Num Ckpt Able Jobs",
 }
 
@@ -68,7 +66,6 @@ DEFAULT_FILTER_ATTRS = [
     "NumJobStarts",
     "NumShadowStarts",
     "NumHolds",
-    "JobUniverse",
     "JobStatus",
     "EnteredCurrentStatus",
     "BytesSent",
@@ -100,7 +97,12 @@ class PathScheddCpuFilter(BaseFilter):
                                     "lt": end_ts,
                                 }
                             }}
-                        ]
+                        ],
+                        "must_not": [
+                            {"terms": {
+                                "JobUniverse": [7, 12]
+                            }},
+                        ],
                     }
                 }
             }
@@ -121,7 +123,7 @@ class PathScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["User"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -129,31 +131,22 @@ class PathScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -185,7 +178,7 @@ class PathScheddCpuFilter(BaseFilter):
         filter_attrs = DEFAULT_FILTER_ATTRS.copy()
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -193,31 +186,22 @@ class PathScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -250,7 +234,7 @@ class PathScheddCpuFilter(BaseFilter):
         filter_attrs = filter_attrs + ["ScheddName", "ProjectName"]
 
         # Count number of DAGNode Jobs
-        if i.get("DAGNodeName") is not None and i.get("JobUniverse")!=12:
+        if i.get("DAGNodeName") is not None:
             o["_NumDAGNodes"].append(1)
         else:
             o["_NumDAGNodes"].append(0)
@@ -258,31 +242,22 @@ class PathScheddCpuFilter(BaseFilter):
         # Count number of history ads (i.e. number of unique job ids)
         o["_NumJobs"].append(1)
 
-        # Do filtering for scheduler and local universe jobs
-        univ = i.get("JobUniverse", 5)
-        o["_NumSchedulerUnivJobs"].append(univ == 7)
-        o["_NumLocalUnivJobs"].append(univ == 12)
-        o["_NoShadow"].append(univ in [7, 12])
-
         # Count number of checkpointable jobs
-        if univ == 5 and (
-                (
-                    i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
-                    i.get("Is_resumable", False)
-                ) or (
-                    i.get("SuccessCheckpointExitBySignal", False) or
-                    i.get("SuccessCheckpointExitCode") is not None
-                )):
+        if  (
+                i.get("WhenToTransferOutput", "").upper() == "ON_EXIT_OR_EVICT" and
+                i.get("Is_resumable", False)
+            ) or (
+                i.get("SuccessCheckpointExitBySignal", False) or
+                i.get("SuccessCheckpointExitCode") is not None
+            ):
             o["_NumCkptJobs"].append(1)
         else:
             o["_NumCkptJobs"].append(0)
 
         # Compute badput fields
         if (
-                univ not in [7, 12] and
                 i.get("NumJobStarts", 0) > 1 and
                 i.get("RemoteWallClockTime", 0) > 0 and
-                #i.get("RemoteWallClockTime") != int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
                 i.get("RemoteWallClockTime") != i.get("CommittedTime", 0)
             ):
             o["_BadWallClockTime"].append(i["RemoteWallClockTime"] - int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0)))))
@@ -362,16 +337,11 @@ class PathScheddCpuFilter(BaseFilter):
         # Don't count starts and shadows for jobs that don't/shouldn't have shadows
         num_exec_attempts = []
         num_shadow_starts = []
-        for (job_starts, shadow_starts, no_shadow) in zip(
+        for (job_starts, shadow_starts) in zip(
                 data["NumJobStarts"],
-                data["NumShadowStarts"],
-                data["_NoShadow"]):
-            if no_shadow:
-                num_exec_attempts.append(None)
-                num_shadow_starts.append(None)
-            else:
-                num_exec_attempts.append(job_starts)
-                num_shadow_starts.append(shadow_starts)
+                data["NumShadowStarts"]):
+            num_exec_attempts.append(job_starts)
+            num_shadow_starts.append(shadow_starts)
 
         # Short jobs are jobs that ran for < 1 minute
         is_short_job = []
@@ -394,15 +364,12 @@ class PathScheddCpuFilter(BaseFilter):
         # so filter out short jobs and removed jobs,
         # and sort them so we can easily grab the percentiles later
         long_times_sorted = []
-        for (is_short, last_wallclock_time, committed_time, no_shadow, job_status) in zip(
+        for (is_short, committed_time, job_status) in zip(
                 is_short_job,
-                data["lastremotewallclocktime"],
                 data["CommittedTime"],
-                data["_NoShadow"],
                 data["JobStatus"]):
-            #goodput_time = last_wallclock_time or committed_time
             goodput_time = committed_time
-            if (is_short == False) and (no_shadow == False) and (job_status != 3):
+            if (is_short is False) and (job_status != 3):
                 long_times_sorted.append(goodput_time)
         long_times_sorted = self.clean(long_times_sorted)
         long_times_sorted.sort()
@@ -416,7 +383,6 @@ class PathScheddCpuFilter(BaseFilter):
         output_files_total_job_stops = []
         for (
                 job_status,
-                job_universe,
                 job_starts,
                 input_stats,
                 input_cedar_bytes,
@@ -424,20 +390,12 @@ class PathScheddCpuFilter(BaseFilter):
                 output_cedar_bytes,
             ) in zip(
                 data["JobStatus"],
-                data["JobUniverse"],
                 data["NumJobStarts"],
                 data["transferinputstats"],
                 data["BytesRecvd"],
                 data["transferoutputstats"],
                 data["BytesSent"],
             ):
-
-            if job_universe in {7, 12}:
-                input_files_total_count.append(None)
-                input_files_total_job_starts.append(None)
-                output_files_total_count.append(None)
-                output_files_total_job_stops.append(None)
-                continue
 
             input_files_count = 0
             input_files_bytes = 0
@@ -528,8 +486,6 @@ class PathScheddCpuFilter(BaseFilter):
         row["Max Rqst Cpus"]    = max(self.clean(data["RequestCpus"], allow_empty_list=False))
         row["Num Exec Atts"]    = sum(self.clean(num_exec_attempts))
         row["Num Shadw Starts"] = sum(self.clean(num_shadow_starts))
-        row["Num Local Univ Jobs"] = sum(data["_NumLocalUnivJobs"])
-        row["Num Sched Univ Jobs"] = sum(data["_NumSchedulerUnivJobs"])
         row["Num Ckpt Able Jobs"] = sum(data["_NumCkptJobs"])
 
         # Compute derivative columns

--- a/accounting/formatters/ChtcScheddCpuFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuFormatter.py
@@ -161,8 +161,6 @@ class ChtcScheddCpuFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/ChtcScheddCpuOspoolFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuOspoolFormatter.py
@@ -161,8 +161,6 @@ class ChtcScheddCpuOspoolFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/ChtcScheddCpuRemovedFormatter.py
@@ -85,7 +85,7 @@ class ChtcScheddCpuRemovedFormatter(BaseFormatter):
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"
         custom_items["Max Used Mem MB"]  = "Maximum measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst Cpus"]    = "Maximum number of CPUs requested across all submitted jobs"
-        
+
         custom_items["CPU Hours / Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
         custom_items["Rm'd Jobs w/o Shadw Start"] = "Number of jobs that were removed from the queue before any shadow starts"
         custom_items["% Jobs w/o Shadw"] = "Percentage of removed jobs that never had a shadow start, i.e. were removed before running"
@@ -100,7 +100,5 @@ class ChtcScheddCpuRemovedFormatter(BaseFormatter):
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Num Exec Atts"]    = "Total number of execution attempts (excluding Local and Scheduler Universe jobs)"
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
         html = super().get_legend(custom_items)
         return html

--- a/accounting/formatters/ChtcScheddGpuFormatter.py
+++ b/accounting/formatters/ChtcScheddGpuFormatter.py
@@ -160,8 +160,6 @@ class ChtcScheddGpuFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/IgwnScheddCpuFormatter.py
+++ b/accounting/formatters/IgwnScheddCpuFormatter.py
@@ -161,8 +161,6 @@ class IgwnScheddCpuFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/OsgScheddCpuFormatter.py
+++ b/accounting/formatters/OsgScheddCpuFormatter.py
@@ -178,8 +178,6 @@ class OsgScheddCpuFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/OsgScheddCpuHeldFormatter.py
+++ b/accounting/formatters/OsgScheddCpuHeldFormatter.py
@@ -157,7 +157,7 @@ class OsgScheddCpuHeldFormatter(BaseFormatter):
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"
         custom_items["Max Used Mem MB"]  = "Maximum measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst Cpus"]    = "Maximum number of CPUs requested across all submitted jobs"
-        
+
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"
         custom_items["Num Exec Atts"]    = "Total number of execution attempts (excluding Local and Scheduler Universe jobs)"
         custom_items["Num Rm'd Jobs"]    = "Number of jobs that were removed from the queue instead of allowing to complete"
@@ -180,8 +180,6 @@ class OsgScheddCpuHeldFormatter(BaseFormatter):
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
         html = super().get_legend(custom_items)
         return html
 

--- a/accounting/formatters/OsgScheddCpuRemovedFormatter.py
+++ b/accounting/formatters/OsgScheddCpuRemovedFormatter.py
@@ -87,7 +87,7 @@ class OsgScheddCpuRemovedFormatter(BaseFormatter):
         custom_items["Max Rqst Mem MB"]  = "Maximum memory requested across all submitted jobs in MB"
         custom_items["Max Used Mem MB"]  = "Maximum measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst Cpus"]    = "Maximum number of CPUs requested across all submitted jobs"
-        
+
         custom_items["CPU Hours / Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
         custom_items["Rm'd Jobs w/o Shadw Start"] = "Number of jobs that were removed from the queue before any shadow starts"
         custom_items["% Jobs w/o Shadw"] = "Percentage of removed jobs that never had a shadow start, i.e. were removed before running"
@@ -102,7 +102,5 @@ class OsgScheddCpuRemovedFormatter(BaseFormatter):
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Num Exec Atts"]    = "Total number of execution attempts (excluding Local and Scheduler Universe jobs)"
         custom_items["Num Shadw Starts"] = "Total times a condor_shadow was spawned across all submitted jobs (excluding Local and Scheduler Universe jobs)"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
         html = super().get_legend(custom_items)
         return html

--- a/accounting/formatters/OsgScheddGpuFormatter.py
+++ b/accounting/formatters/OsgScheddGpuFormatter.py
@@ -163,8 +163,6 @@ class OsgScheddGpuFormatter(BaseFormatter):
         custom_items["Output MB / File"] = "Average size of file in output sandboxes"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
 
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
         custom_items["Max Rqst/Used Disk GB"] = "Maximum requested/used disk space across all submittted jobs' last execution attempts in GB"

--- a/accounting/formatters/PathScheddCpuFormatter.py
+++ b/accounting/formatters/PathScheddCpuFormatter.py
@@ -129,8 +129,6 @@ class PathScheddCpuFormatter(BaseFormatter):
         custom_items["Med Used Mem MB"]  = "Median measured memory usage across all submitted jobs' last execution attempts in MB"
 
         custom_items["CPU Hours / Bad Exec Att"] = "Average CPU Hours used in a non-final execution attempt"
-        custom_items["Num Local Univ Jobs"] = "Number of jobs that used local universe"
-        custom_items["Num Sched Univ Jobs"] = "Number of jobs that used scheduler universe"
         html = super().get_legend(custom_items)
         return html
 


### PR DESCRIPTION
There are a lot of diffs, but they all do the same things:
1. Add a filter to the Elasticsearch query to ignore local and scheduler universe jobs
2. Remove checks for local and scheduler universe (i.e. no shadow) jobs
3. Update the rest of the code to account for the lack of those checks
4. Remove the local and scheduler universe columns and legend entries