### PR TITLE
(INF-2931) Fix csv names for "CHTC AP usage on OSPool" reports

### DIFF
--- a/accounting/filters/ChtcScheddCpuOspoolFilter.py
+++ b/accounting/filters/ChtcScheddCpuOspoolFilter.py
@@ -108,7 +108,7 @@ DEFAULT_FILTER_ATTRS = [
 
 
 class ChtcScheddCpuOspoolFilter(BaseFilter):
-    name = "CHTC schedd job history"
+    name = "CHTC schedd OSPool usage job history"
 
     def __init__(self, **kwargs):
         self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}

--- a/accounting/filters/ChtcScheddCpuOspoolMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuOspoolMonthlyFilter.py
@@ -73,7 +73,7 @@ DEFAULT_COLUMNS = {
 
 
 class ChtcScheddCpuOspoolMonthlyFilter(BaseFilter):
-    name = "CHTC schedd job history"
+    name = "CHTC schedd OSPool usage job history"
 
     def __init__(self, **kwargs):
         self.collector_hosts = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}


### PR DESCRIPTION
Fixes for the csv names to include "OSPool" for INF-2931.