### PR TITLE
INF-3590 Floor resource requests to provisioned resources

### DIFF
--- a/accounting/filters/ChtcScheddCpuFilter.py
+++ b/accounting/filters/ChtcScheddCpuFilter.py
@@ -146,6 +146,9 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -189,9 +192,9 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -203,6 +206,8 @@ class ChtcScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -210,6 +215,9 @@ class ChtcScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -255,9 +263,9 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -272,6 +280,8 @@ class ChtcScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -280,6 +290,9 @@ class ChtcScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -325,9 +338,9 @@ class ChtcScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -339,6 +352,8 @@ class ChtcScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 

--- a/accounting/filters/ChtcScheddCpuMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuMonthlyFilter.py
@@ -113,7 +113,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         is_exec = i.get("NumJobStarts", 0) >= 1
         is_multiexec = i.get("NumJobStarts", 0) > 1
         has_holds = i.get("NumHolds", 0) > 0
-        is_over_rqst_disk = i.get("DiskUsage", 0) > i.get("RequestDisk", 1000)
+        is_over_rqst_disk = i.get("DiskUsage", 0) > f.get("FlooredRequestDisk", 1000)
         is_singularity_job = i.get("SingularityImage") is not None
         has_activation_duration = i.get("activationduration") is not None
         if has_activation_duration:
@@ -146,9 +146,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         elif not is_removed:
             goodput_time = int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 0))))
         job_units = get_job_units(
-            cpus=i.get("RequestCpus", 1),
-            memory_gb=i.get("RequestMemory", 1024)/1024,
-            disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+            cpus=f.get("FlooredRequestCpus", 1),
+            memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+            disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
         )
         input_files = 0
         input_bytes = 0
@@ -224,9 +224,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         sum_cols["TotalActivationSetupDuration"] = int(activation_setup_duration)
 
         sum_cols["TotalLongJobWallClockTime"] = long_job_wallclock_time
-        sum_cols["GoodCpuTime"] = (goodput_time * max(i.get("RequestCpus", 1), 1))
-        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(i.get("RequestCpus", 1), 1))
-        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(i.get("RequestCpus", 1), 1))
+        sum_cols["GoodCpuTime"] = (goodput_time * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(f.get("FlooredRequestCpus", 1), 1))
         sum_cols["JobUnitTime"] = job_units * i.get("RemoteWallClockTime", 0)
         sum_cols["NumShadowStarts"] = i.get("NumShadowStarts", 0)
         sum_cols["NumJobStarts"] = i.get("NumJobStarts", 0)
@@ -248,11 +248,11 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
 
         max_cols = {}
         max_cols["MaxLongJobWallClockTime"] = long_job_wallclock_time
-        max_cols["MaxRequestMemory"] = i.get("RequestMemory", 0)
+        max_cols["MaxRequestMemory"] = f.get("FlooredRequestMemory", 0)
         max_cols["MaxMemoryUsage"] = i.get("MemoryUsage", 0)
-        max_cols["MaxRequestDisk"] = i.get("RequestDisk", 0)
+        max_cols["MaxRequestDisk"] = f.get("FlooredRequestDisk", 0)
         max_cols["MaxDiskUsage"] = i.get("DiskUsage", 0)
-        max_cols["MaxRequestCpus"] = i.get("RequestCpus", 1)
+        max_cols["MaxRequestCpus"] = f.get("FlooredRequestCpus", 1)
         max_cols["MaxJobUnits"] = job_units
 
         min_cols = {}
@@ -273,6 +273,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         output = data["Schedds"][schedd]
@@ -284,6 +287,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -309,6 +315,9 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", i.get("projectname", "UNKNOWN"))) or "UNKNOWN"

--- a/accounting/filters/ChtcScheddCpuMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuMonthlyFilter.py
@@ -80,33 +80,29 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         # (Dict has same structure as the REST API query language)
         query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query.update({
-            "body": {
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {"range": {
-                                "RecordTime": {
-                                   "gte": start_ts,
-                                    "lt": end_ts,
-                                }
-                            }},
-                            {"regexp": {
-                                "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
-                            }}
-                        ],
-                        "must_not": [
-                            {"terms": {
-                                "JobUniverse": [7, 12]
-                            }},
-                        ],
-                    }
-                }
+        query["body"]["query"].update({
+            "bool": {
+                "filter": [
+                    {"range": {
+                        "RecordTime": {
+                            "gte": start_ts,
+                            "lt": end_ts,
+                        }
+                    }},
+                    {"regexp": {
+                        "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
+                    }}
+                ],
+                "must_not": [
+                    {"terms": {
+                        "JobUniverse": [7, 12]
+                    }},
+                ],
             }
         })
         return query
 
-    def reduce_data(self, i, o, t, is_site=False):
+    def reduce_data(self, i, f, o, t, is_site=False):
 
         is_removed = i.get("JobStatus") == 3
         is_dagnode = i.get("DAGNodeName") is not None
@@ -281,7 +277,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         output = data["Schedds"][schedd]
         total = data["Schedds"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
     def user_filter(self, data, doc):
 
@@ -296,7 +292,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         output = data["Users"][user]
         total = data["Users"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         counter_cols = {}
         counter_cols["ScheddNames"] = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
@@ -324,7 +320,7 @@ class ChtcScheddCpuMonthlyFilter(BaseFilter):
         output = data["Projects"][project]
         total = data["Projects"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         dict_cols = {}
         dict_cols["Users"] = i.get("User", "UNKNOWN") or "UNKNOWN"

--- a/accounting/filters/ChtcScheddCpuOspoolFilter.py
+++ b/accounting/filters/ChtcScheddCpuOspoolFilter.py
@@ -231,6 +231,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -278,9 +281,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -292,6 +295,8 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -299,6 +304,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -349,9 +357,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -366,6 +374,8 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -374,6 +384,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -423,9 +436,9 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -437,6 +450,8 @@ class ChtcScheddCpuOspoolFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 

--- a/accounting/filters/ChtcScheddCpuOspoolMonthlyFilter.py
+++ b/accounting/filters/ChtcScheddCpuOspoolMonthlyFilter.py
@@ -145,33 +145,29 @@ class ChtcScheddCpuOspoolMonthlyFilter(BaseFilter):
         # (Dict has same structure as the REST API query language)
         query = super().get_query(index, start_ts, end_ts, **kwargs)
 
-        query.update({
-            "body": {
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {"range": {
-                                "RecordTime": {
-                                   "gte": start_ts,
-                                    "lt": end_ts,
-                                }
-                            }},
-                            {"regexp": {
-                                "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
-                            }}
-                        ],
-                        "must_not": [
-                            {"terms": {
-                                "JobUniverse": [7, 12]
-                            }},
-                        ],
-                    }
-                }
+        query["body"]["query"].update({
+            "bool": {
+                "filter": [
+                    {"range": {
+                        "RecordTime": {
+                            "gte": start_ts,
+                            "lt": end_ts,
+                        }
+                    }},
+                    {"regexp": {
+                        "ScheddName.keyword": ".*[.]chtc[.]wisc[.]edu"
+                    }}
+                ],
+                "must_not": [
+                    {"terms": {
+                        "JobUniverse": [7, 12]
+                    }},
+                ],
             }
         })
         return query
 
-    def reduce_data(self, i, o, t, is_site=False):
+    def reduce_data(self, i, f, o, t, is_site=False):
 
         is_removed = i.get("JobStatus") == 3
         is_dagnode = i.get("DAGNodeName") is not None
@@ -350,7 +346,7 @@ class ChtcScheddCpuOspoolMonthlyFilter(BaseFilter):
         output = data["Schedds"][schedd]
         total = data["Schedds"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
     def user_filter(self, data, doc):
 
@@ -369,7 +365,7 @@ class ChtcScheddCpuOspoolMonthlyFilter(BaseFilter):
         output = data["Users"][user]
         total = data["Users"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         counter_cols = {}
         counter_cols["ScheddNames"] = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
@@ -401,7 +397,7 @@ class ChtcScheddCpuOspoolMonthlyFilter(BaseFilter):
         output = data["Projects"][project]
         total = data["Projects"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         dict_cols = {}
         dict_cols["Users"] = i.get("User", "UNKNOWN") or "UNKNOWN"

--- a/accounting/filters/ChtcScheddCpuRemovedFilter.py
+++ b/accounting/filters/ChtcScheddCpuRemovedFilter.py
@@ -97,6 +97,9 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -135,12 +138,18 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -184,6 +193,8 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -191,6 +202,9 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -231,7 +245,10 @@ class ChtcScheddCpuRemovedFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/ChtcScheddDSIGpuFilter.py
+++ b/accounting/filters/ChtcScheddDSIGpuFilter.py
@@ -83,6 +83,9 @@ class ChtcScheddDSIGpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
         o = data["Projects"][project]
@@ -133,6 +136,8 @@ class ChtcScheddDSIGpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -141,6 +146,9 @@ class ChtcScheddDSIGpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that were removed
         if i.get("JobStatus", 4) == 3:
@@ -164,7 +172,10 @@ class ChtcScheddDSIGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/ChtcScheddGpuFilter.py
+++ b/accounting/filters/ChtcScheddGpuFilter.py
@@ -144,6 +144,9 @@ class ChtcScheddGpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -186,12 +189,18 @@ class ChtcScheddGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -239,6 +248,8 @@ class ChtcScheddGpuFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -247,6 +258,9 @@ class ChtcScheddGpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -296,6 +310,8 @@ class ChtcScheddGpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -304,6 +320,9 @@ class ChtcScheddGpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that were removed
         if i.get("JobStatus", 4) == 3:
@@ -327,7 +346,10 @@ class ChtcScheddGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/ChtcScheddJobDistroFilter.py
+++ b/accounting/filters/ChtcScheddJobDistroFilter.py
@@ -168,13 +168,16 @@ class ChtcScheddJobDistroFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict
         requests = data["JobRequests"]
         usages = data["JobUsages"]
 
         # Check for missing attrs
-        request_disk = i.get("RequestDisk")
-        request_memory = i.get("RequestMemory")
+        request_disk = f.get("FlooredRequestDisk")
+        request_memory = f.get("FlooredRequestMemory")
         skip_requests = None in [request_disk, request_memory]
 
         usage_disk = i.get("DiskUsage_RAW", i.get("DiskUsage"))
@@ -185,7 +188,7 @@ class ChtcScheddJobDistroFilter(BaseFilter):
             total_jobs = requests.get("TotalJobs", 0)
             requests["TotalJobs"] = total_jobs + 1
             # Filter out jobs that request more than one core
-            if not i.get("RequestCpus", 1) > 1:
+            if not f.get("FlooredRequestCpus", 1) > 1:
                 histogram = requests.get("Histogram", defaultdict(int))
                 q_request_disk = self.quantize_disk(request_disk)
                 q_request_memory = self.quantize_memory(request_memory)
@@ -198,7 +201,7 @@ class ChtcScheddJobDistroFilter(BaseFilter):
             total_jobs = usages.get("TotalJobs", 0)
             usages["TotalJobs"] = total_jobs + 1
             # Filter out jobs that request more than one core
-            if not i.get("RequestCpus", 1) > 1:
+            if not f.get("FlooredRequestCpus", 1) > 1:
                 histogram = usages.get("Histogram", defaultdict(int))
                 q_usage_disk = self.quantize_disk(usage_disk)
                 q_usage_memory = self.quantize_memory(usage_memory)

--- a/accounting/filters/IgwnScheddCpuFilter.py
+++ b/accounting/filters/IgwnScheddCpuFilter.py
@@ -146,6 +146,9 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -189,9 +192,9 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -203,6 +206,8 @@ class IgwnScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -210,6 +215,9 @@ class IgwnScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -255,9 +263,9 @@ class IgwnScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -272,6 +280,8 @@ class IgwnScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 

--- a/accounting/filters/IgwnScheddCpuMonthlyFilter.py
+++ b/accounting/filters/IgwnScheddCpuMonthlyFilter.py
@@ -117,7 +117,7 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
                 i.get("SuccessCheckpointExitBySignal", False) or
                 i.get("SuccessCheckpointExitCode") is not None
         ))
-        is_over_disk_request = i.get("DiskUsage", 0) > i.get("RequestDisk", 1)
+        is_over_disk_request = i.get("DiskUsage", 0) > f.get("FlooredRequestDisk", 1)
         goodput_time = 0
         if not is_removed:
             goodput_time = int(float(i.get("lastremotewallclockTime", i.get("CommittedTime", 0))))
@@ -167,9 +167,9 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
                 input_bytes += i.get("BytesRecvd", 0)
                 output_bytes += i.get("BytesSent", 0)
         job_units = get_job_units(
-            cpus=i.get("RequestCpus", 1),
-            memory_gb=i.get("RequestMemory", 1024)/1024,
-            disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+            cpus=f.get("FlooredRequestCpus", 1),
+            memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+            disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
         )
         long_job_wallclock_time = int(is_long) * int(float(i.get("lastremotewallclocktime", i.get("CommittedTime", 60))))
 
@@ -186,9 +186,9 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
         sum_cols["OverDiskJobs"] = int(is_over_disk_request)
 
         sum_cols["TotalLongJobWallClockTime"] = long_job_wallclock_time
-        sum_cols["GoodCpuTime"] = (goodput_time * max(i.get("RequestCpus", 1), 1))
-        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(i.get("RequestCpus", 1), 1))
-        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(i.get("RequestCpus", 1), 1))
+        sum_cols["GoodCpuTime"] = (goodput_time * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(f.get("FlooredRequestCpus", 1), 1))
         sum_cols["JobUnitTime"] = job_units * i.get("RemoteWallClockTime", 0)
         sum_cols["NumShadowStarts"] = i.get("NumShadowStarts", 0)
         sum_cols["NumJobStarts"] = i.get("NumJobStarts", 0)
@@ -209,11 +209,11 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
 
         max_cols = {}
         max_cols["MaxLongJobWallClockTime"] = long_job_wallclock_time
-        max_cols["MaxRequestMemory"] = i.get("RequestMemory", 0)
+        max_cols["MaxRequestMemory"] = f.get("FlooredRequestMemory", 0)
         max_cols["MaxMemoryUsage"] = i.get("MemoryUsage", 0)
-        max_cols["MaxRequestDisk"] = i.get("RequestDisk", 0)
+        max_cols["MaxRequestDisk"] = f.get("FlooredRequestDisk", 0)
         max_cols["MaxDiskUsage"] = i.get("DiskUsage", 0)
-        max_cols["MaxRequestCpus"] = i.get("RequestCpus", 1)
+        max_cols["MaxRequestCpus"] = f.get("FlooredRequestCpus", 1)
         max_cols["MaxJobUnits"] = job_units
 
         min_cols = {}
@@ -234,6 +234,9 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         output = data["Schedds"][schedd]
@@ -245,6 +248,9 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"

--- a/accounting/filters/IgwnScheddCpuMonthlyFilter.py
+++ b/accounting/filters/IgwnScheddCpuMonthlyFilter.py
@@ -99,7 +99,7 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
         })
         return query
 
-    def reduce_data(self, i, o, t, is_site=False):
+    def reduce_data(self, i, f, o, t, is_site=False):
 
         is_removed = i.get("JobStatus") == 3
         is_dagnode = i.get("DAGNodeName") is not None
@@ -241,7 +241,7 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
         output = data["Schedds"][schedd]
         total = data["Schedds"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
     def user_filter(self, data, doc):
 
@@ -256,7 +256,7 @@ class IgwnScheddCpuMonthlyFilter(BaseFilter):
         output = data["Users"][user]
         total = data["Users"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         counter_cols = {}
         counter_cols["ScheddNames"] = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -301,6 +301,9 @@ class OsgScheddCpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc["fields"].items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -345,21 +348,27 @@ class OsgScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc["fields"].items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -406,9 +415,9 @@ class OsgScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -418,6 +427,8 @@ class OsgScheddCpuFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -425,6 +436,9 @@ class OsgScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc["fields"].items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -471,9 +485,9 @@ class OsgScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
@@ -492,13 +506,19 @@ class OsgScheddCpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
 
     def institution_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc["fields"].items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i):
@@ -536,16 +556,19 @@ class OsgScheddCpuFilter(BaseFilter):
         # Compute job units
         if i.get("RemoteWallClockTime", 0) > 0:
             o["NumJobUnits"].append(get_job_units(
-                cpus=i.get("RequestCpus", 1),
-                memory_gb=i.get("RequestMemory", 1024)/1024,
-                disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+                cpus=f.get("FlooredRequestCpus", 1),
+                memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+                disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
             ))
         else:
             o["NumJobUnits"].append(None)
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/OsgScheddCpuFilter.py
+++ b/accounting/filters/OsgScheddCpuFilter.py
@@ -302,7 +302,7 @@ class OsgScheddCpuFilter(BaseFilter):
         i = doc["_source"]
 
         # Get computed fields (as single values instead of arrays)
-        f = {k: v[0] for k, v in doc["fields"].items()}
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
@@ -368,7 +368,7 @@ class OsgScheddCpuFilter(BaseFilter):
         i = doc["_source"]
 
         # Get computed fields (as single values instead of arrays)
-        f = {k: v[0] for k, v in doc["fields"].items()}
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -438,7 +438,7 @@ class OsgScheddCpuFilter(BaseFilter):
         i = doc["_source"]
 
         # Get computed fields (as single values instead of arrays)
-        f = {k: v[0] for k, v in doc["fields"].items()}
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -518,7 +518,7 @@ class OsgScheddCpuFilter(BaseFilter):
         i = doc["_source"]
 
         # Get computed fields (as single values instead of arrays)
-        f = {k: v[0] for k, v in doc["fields"].items()}
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i):

--- a/accounting/filters/OsgScheddCpuHeldFilter.py
+++ b/accounting/filters/OsgScheddCpuHeldFilter.py
@@ -229,6 +229,9 @@ class OsgScheddCpuHeldFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -263,12 +266,18 @@ class OsgScheddCpuHeldFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -308,6 +317,8 @@ class OsgScheddCpuHeldFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -315,6 +326,9 @@ class OsgScheddCpuHeldFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -351,7 +365,10 @@ class OsgScheddCpuHeldFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -254,7 +254,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
             i.get("SuccessCheckpointExitBySignal", False) or
             i.get("SuccessCheckpointExitCode") is not None
         )
-        is_over_disk_request = i.get("DiskUsage", 0) > i.get("RequestDisk", 1)
+        is_over_disk_request = i.get("DiskUsage", 0) > f.get("FlooredRequestDisk", 1)
         goodput_time = 0
         if not is_removed:
             goodput_time = i.get("LastRemoteWallClockTime", i.get("CommittedTime", 0))
@@ -304,9 +304,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
                 input_bytes += i.get("BytesRecvd", 0)
                 output_bytes += i.get("BytesSent", 0)
         job_units = get_job_units(
-            cpus=i.get("RequestCpus", 1),
-            memory_gb=i.get("RequestMemory", 1024)/1024,
-            disk_gb=i.get("RequestDisk", 1024**2)/1024**2,
+            cpus=f.get("FlooredRequestCpus", 1),
+            memory_gb=f.get("FlooredRequestMemory", 1024)/1024,
+            disk_gb=f.get("FlooredRequestDisk", 1024**2)/1024**2,
         )
         long_job_wallclock_time = int(is_long) * i.get("LastRemoteWallClockTime", i.get("CommittedTime", 60))
         has_num_vacates_by_reason = False
@@ -328,9 +328,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         sum_cols["OverDiskJobs"] = int(is_over_disk_request)
 
         # sum_cols["TotalLongJobWallClockTime"] = long_job_wallclock_time
-        sum_cols["GoodCpuTime"] = (goodput_time * max(i.get("RequestCpus", 1), 1))
-        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(i.get("RequestCpus", 1), 1))
-        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(i.get("RequestCpus", 1), 1))
+        sum_cols["GoodCpuTime"] = (goodput_time * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["CpuTime"] = (i.get("RemoteWallClockTime", 0) * max(f.get("FlooredRequestCpus", 1), 1))
+        sum_cols["BadCpuTime"] = ((i.get("RemoteWallClockTime", 0) - goodput_time) * max(f.get("FlooredRequestCpus", 1), 1))
         sum_cols["JobUnitTime"] = job_units * i.get("RemoteWallClockTime", 0)
         sum_cols["NumShadowStarts"] = i.get("NumShadowStarts", 0)
         sum_cols["NumJobStarts"] = i.get("NumJobStarts", 0)
@@ -363,11 +363,11 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
 
         max_cols = {}
         # max_cols["MaxLongJobWallClockTime"] = long_job_wallclock_time
-        max_cols["MaxRequestMemory"] = i.get("RequestMemory", 0)
+        max_cols["MaxRequestMemory"] = f.get("FlooredRequestMemory", 0)
         max_cols["MaxMemoryUsage"] = i.get("MemoryUsage", 0)
-        max_cols["MaxRequestDisk"] = i.get("RequestDisk", 0)
+        max_cols["MaxRequestDisk"] = f.get("FlooredRequestDisk", 0)
         max_cols["MaxDiskUsage"] = i.get("DiskUsage", 0)
-        max_cols["MaxRequestCpus"] = i.get("RequestCpus", 1)
+        max_cols["MaxRequestCpus"] = f.get("FlooredRequestCpus", 1)
         max_cols["MaxJobUnits"] = job_units
 
         min_cols = {}
@@ -388,6 +388,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i.get("ScheddName"), i.get("LastRemotePool")):
             return
@@ -403,6 +406,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i.get("ScheddName"), i.get("LastRemotePool")):
@@ -431,6 +437,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i.get("ScheddName"), i.get("LastRemotePool")):
@@ -467,6 +476,9 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i.get("ScheddName"), i.get("LastRemotePool")):

--- a/accounting/filters/OsgScheddCpuMonthlyFilter.py
+++ b/accounting/filters/OsgScheddCpuMonthlyFilter.py
@@ -240,7 +240,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
                 return bool(remote_pools & self.collector_hosts)
         return False
 
-    def reduce_data(self, i, o, t, is_site=False):
+    def reduce_data(self, i, f, o, t, is_site=False):
 
         is_removed = i.get("JobStatus") == 3
         is_dagnode = i.get("DAGNodeName") is not None
@@ -400,7 +400,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         output = data["Schedds"][schedd]
         total = data["Schedds"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
     def user_filter(self, data, doc):
 
@@ -419,7 +419,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         output = data["Users"][user]
         total = data["Users"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         counter_cols = {}
         counter_cols["ScheddNames"] = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
@@ -450,7 +450,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         output = data["Projects"][project]
         total = data["Projects"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         dict_cols = {}
         dict_cols["Users"] = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -500,7 +500,7 @@ class OsgScheddCpuMonthlyFilter(BaseFilter):
         output = data["Institution"][institution]
         total = data["Institution"]["TOTAL"]
 
-        self.reduce_data(i, output, total)
+        self.reduce_data(i, f, output, total)
 
         dict_cols = {}
         dict_cols["Users"] = i.get("User", "UNKNOWN") or "UNKNOWN"

--- a/accounting/filters/OsgScheddCpuRemovedFilter.py
+++ b/accounting/filters/OsgScheddCpuRemovedFilter.py
@@ -155,6 +155,9 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -197,12 +200,18 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -250,6 +259,8 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -257,6 +268,9 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -301,7 +315,10 @@ class OsgScheddCpuRemovedFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/OsgScheddCpuRetryFilter.py
+++ b/accounting/filters/OsgScheddCpuRetryFilter.py
@@ -127,6 +127,9 @@ class OsgScheddCpuRetryFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -143,12 +146,18 @@ class OsgScheddCpuRetryFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -170,6 +179,8 @@ class OsgScheddCpuRetryFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -177,6 +188,9 @@ class OsgScheddCpuRetryFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -195,7 +209,10 @@ class OsgScheddCpuRetryFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/OsgScheddGpuFilter.py
+++ b/accounting/filters/OsgScheddGpuFilter.py
@@ -318,6 +318,9 @@ class OsgScheddGpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
         o = data["Schedds"][schedd]
@@ -361,12 +364,18 @@ class OsgScheddGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def user_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -415,6 +424,8 @@ class OsgScheddGpuFilter(BaseFilter):
             # Use UNKNOWN for missing or blank ProjectName and ScheddName
             if attr in {"ScheddName", "ProjectName"}:
                 o[attr].append(i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN")
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -422,6 +433,9 @@ class OsgScheddGpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
@@ -479,13 +493,19 @@ class OsgScheddGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
 
     def institution_filter(self, data, doc):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Filter out jobs that did not run in the OS pool
         if not self.is_ospool_job(i):
@@ -522,7 +542,10 @@ class OsgScheddGpuFilter(BaseFilter):
 
         # Add attr values to the output dict, use None if missing
         for attr in filter_attrs:
-            o[attr].append(i.get(attr, None))
+            if attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
+            else:
+                o[attr].append(i.get(attr, None))
 
     def get_filters(self):
         # Add all filter methods to a list

--- a/accounting/filters/OsgScheddLongJobFilter.py
+++ b/accounting/filters/OsgScheddLongJobFilter.py
@@ -170,6 +170,9 @@ class OsgScheddLongJobFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
         o = data["Users"][user]
@@ -198,7 +201,9 @@ class OsgScheddLongJobFilter(BaseFilter):
                             "LastRemoteHost"}:
                 o[attr][0] = i.get(attr, i.get(attr.lower(), "UNKNOWN")) or "UNKNOWN"
             elif attr in {"RequestGpus"}:
-                o[attr][0] = i.get(attr, 0)
+                o[attr][0] = f.get("FlooredRequestGpus", i.get("RequestGpus", 0))
+            elif attr.startswith("Request"):
+                o[attr][0] = f.get(f"Floored{attr}", i.get(attr, None))
             else:
                 o[attr][0] = i.get(attr, None)
 

--- a/accounting/filters/OsgScheddResourcesFilter.py
+++ b/accounting/filters/OsgScheddResourcesFilter.py
@@ -764,7 +764,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Hrs"] = 0
 
-        memory_requests_sorted = self.clean(data['RequestMemory'])
+        memory_requests_sorted = self.clean(data['FlooredRequestMemory'])
         memory_requests_sorted.sort()
         if len(memory_requests_sorted) > 0:
             row["Min Allo Mem"]  = memory_requests_sorted[ 0] / 1024
@@ -783,7 +783,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Allo Mem"] = 0
 
-        memory_hours_requested_sorted = self.clean([x*y if (None not in (x, y)) else None for x, y in zip(data["RequestMemory"], data["RemoteWallClockTime"])])
+        memory_hours_requested_sorted = self.clean([x*y if (None not in (x, y)) else None for x, y in zip(data["FlooredRequestMemory"], data["RemoteWallClockTime"])])
         memory_hours_requested_sorted.sort()
         if len(memory_hours_requested_sorted) > 0:
             row["Min Allo Mem GBh"]  = memory_hours_requested_sorted[ 0] / (1024*3600)
@@ -821,7 +821,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Use Mem"] = 0
 
-        memory_hours_usages_sorted = self.clean([min(req, use)*t if (None not in (req, use, t)) else None for use, req, t in zip(data["MemoryUsage"], data["RequestMemory"], data["RemoteWallClockTime"])])
+        memory_hours_usages_sorted = self.clean([min(req, use)*t if (None not in (req, use, t)) else None for use, req, t in zip(data["MemoryUsage"], data["FlooredRequestMemory"], data["RemoteWallClockTime"])])
         memory_hours_usages_sorted.sort()
         # if len(memory_hours_usages_sorted) > 0:
         #     row["Min Use Mem GBh"]  = memory_hours_usages_sorted[ 0] / (1024*3600)
@@ -840,7 +840,7 @@ class OsgScheddResourcesFilter(BaseFilter):
         #     # There is no variance if there is only one value
         #     row["Stdv Use Mem GBh"] = 0
 
-        memory_unusages_sorted = self.clean([max(req - use, 0) if (None not in (req, use)) else None for req, use in zip(data["RequestMemory"], data["MemoryUsage"])])
+        memory_unusages_sorted = self.clean([max(req - use, 0) if (None not in (req, use)) else None for req, use in zip(data["FlooredRequestMemory"], data["MemoryUsage"])])
         memory_unusages_sorted.sort()
         if len(memory_unusages_sorted) > 0:
             row["Min Unuse Mem"]  = memory_unusages_sorted[ 0] / 1024
@@ -859,7 +859,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Unuse Mem"] = 0
 
-        memory_hours_unusages_sorted = self.clean([max(req - use, 0)*t if (None not in (req, use, t)) else None for req, use, t in zip(data["RequestMemory"], data["MemoryUsage"], data["RemoteWallClockTime"])])
+        memory_hours_unusages_sorted = self.clean([max(req - use, 0)*t if (None not in (req, use, t)) else None for req, use, t in zip(data["FlooredRequestMemory"], data["MemoryUsage"], data["RemoteWallClockTime"])])
         memory_hours_unusages_sorted.sort()
         if len(memory_hours_unusages_sorted) > 0:
             row["Min Unuse Mem GBh"]  = memory_hours_unusages_sorted[ 0] / (1024*3600)
@@ -878,7 +878,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Unuse Mem GBh"] = 0
 
-        memory_utility_sorted = self.clean([100*x/y if ((None not in (x, y,)) and (y > 0)) else None for x, y in zip(data['MemoryUsage'], data['RequestMemory'])])
+        memory_utility_sorted = self.clean([100*x/y if ((None not in (x, y,)) and (y > 0)) else None for x, y in zip(data['MemoryUsage'], data['FlooredRequestMemory'])])
         memory_utility_sorted.sort()
         if len(memory_utility_sorted) > 0:
             row["Min Util% Mem"]  = memory_utility_sorted[ 0]

--- a/accounting/filters/OsgScheddResourcesFilter.py
+++ b/accounting/filters/OsgScheddResourcesFilter.py
@@ -473,7 +473,7 @@ class OsgScheddResourcesFilter(BaseFilter):
         increased_memory = False
         if can_increase_memory:
             try:
-                request_memory = int(f.get("FlooredRequestMemory"))
+                request_memory = int(f.get("FlooredRequestMemory", i.get("RequestMemory")))
                 target_memory = int(TRANSFORM_REQUEST_MEMORY_RE.match(increase_memory_expr).group(1))
                 if target_memory > request_memory:
                     memory_increase_factor = target_memory / request_memory
@@ -657,7 +657,7 @@ class OsgScheddResourcesFilter(BaseFilter):
     #     row["Num Jobs Over Rqst Disk"] = sum([(usage or 0) > (request or 1)
     #         for (usage, request) in zip(data["DiskUsage"], data["RequestDisk"])])
     #     row["Num Short Jobs"]   = sum(self.clean(is_short_job))
-    #     row["Max Rqst Mem MB"]  = max(self.clean(data['RequestMemory'], allow_empty_list=False))
+    #     row["Max Rqst Mem MB"]  = max(self.clean(data["RequestMemory"], allow_empty_list=False))
     #     row["Med Used Mem MB"]  = stats.median(self.clean(data["MemoryUsage"], allow_empty_list=False))
     #     row["Max Used Mem MB"]  = max(self.clean(data["MemoryUsage"], allow_empty_list=False))
     #     row["Max Rqst Disk GB"] = max(self.clean(data["RequestDisk"], allow_empty_list=False)) / (1000*1000)
@@ -796,7 +796,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Hrs"] = 0
 
-        memory_requests_sorted = self.clean(data['FlooredRequestMemory'])
+        memory_requests_sorted = self.clean(data["RequestMemory"])
         memory_requests_sorted.sort()
         if len(memory_requests_sorted) > 0:
             row["Min Allo Mem"]  = memory_requests_sorted[ 0] / 1024
@@ -815,7 +815,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Allo Mem"] = 0
 
-        memory_hours_requested_sorted = self.clean([x*y if (None not in (x, y)) else None for x, y in zip(data["FlooredRequestMemory"], data["RemoteWallClockTime"])])
+        memory_hours_requested_sorted = self.clean([x*y if (None not in (x, y)) else None for x, y in zip(data["RequestMemory"], data["RemoteWallClockTime"])])
         memory_hours_requested_sorted.sort()
         if len(memory_hours_requested_sorted) > 0:
             row["Min Allo Mem GBh"]  = memory_hours_requested_sorted[ 0] / (1024*3600)
@@ -834,7 +834,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Allo Mem GBh"] = 0
 
-        memory_usages_sorted = self.clean(data['MemoryUsage'])
+        memory_usages_sorted = self.clean(data["MemoryUsage"])
         memory_usages_sorted.sort()
         if len(memory_usages_sorted) > 0:
             row["Min Use Mem"]  = memory_usages_sorted[ 0] / 1024
@@ -853,7 +853,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Use Mem"] = 0
 
-        memory_hours_usages_sorted = self.clean([min(req, use)*t if (None not in (req, use, t)) else None for use, req, t in zip(data["MemoryUsage"], data["FlooredRequestMemory"], data["RemoteWallClockTime"])])
+        memory_hours_usages_sorted = self.clean([min(req, use)*t if (None not in (req, use, t)) else None for use, req, t in zip(data["MemoryUsage"], data["RequestMemory"], data["RemoteWallClockTime"])])
         memory_hours_usages_sorted.sort()
         # if len(memory_hours_usages_sorted) > 0:
         #     row["Min Use Mem GBh"]  = memory_hours_usages_sorted[ 0] / (1024*3600)
@@ -872,7 +872,7 @@ class OsgScheddResourcesFilter(BaseFilter):
         #     # There is no variance if there is only one value
         #     row["Stdv Use Mem GBh"] = 0
 
-        memory_unusages_sorted = self.clean([max(req - use, 0) if (None not in (req, use)) else None for req, use in zip(data["FlooredRequestMemory"], data["MemoryUsage"])])
+        memory_unusages_sorted = self.clean([max(req - use, 0) if (None not in (req, use)) else None for req, use in zip(data["RequestMemory"], data["MemoryUsage"])])
         memory_unusages_sorted.sort()
         if len(memory_unusages_sorted) > 0:
             row["Min Unuse Mem"]  = memory_unusages_sorted[ 0] / 1024
@@ -891,7 +891,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Unuse Mem"] = 0
 
-        memory_hours_unusages_sorted = self.clean([max(req - use, 0)*t if (None not in (req, use, t)) else None for req, use, t in zip(data["FlooredRequestMemory"], data["MemoryUsage"], data["RemoteWallClockTime"])])
+        memory_hours_unusages_sorted = self.clean([max(req - use, 0)*t if (None not in (req, use, t)) else None for req, use, t in zip(data["RequestMemory"], data["MemoryUsage"], data["RemoteWallClockTime"])])
         memory_hours_unusages_sorted.sort()
         if len(memory_hours_unusages_sorted) > 0:
             row["Min Unuse Mem GBh"]  = memory_hours_unusages_sorted[ 0] / (1024*3600)
@@ -910,7 +910,7 @@ class OsgScheddResourcesFilter(BaseFilter):
             # There is no variance if there is only one value
             row["Stdv Unuse Mem GBh"] = 0
 
-        memory_utility_sorted = self.clean([100*x/y if ((None not in (x, y,)) and (y > 0)) else None for x, y in zip(data['MemoryUsage'], data['FlooredRequestMemory'])])
+        memory_utility_sorted = self.clean([100*x/y if ((None not in (x, y,)) and (y > 0)) else None for x, y in zip(data["MemoryUsage"], data["RequestMemory"])])
         memory_utility_sorted.sort()
         if len(memory_utility_sorted) > 0:
             row["Min Util% Mem"]  = memory_utility_sorted[ 0]

--- a/accounting/filters/OsgScheddResourcesFilter.py
+++ b/accounting/filters/OsgScheddResourcesFilter.py
@@ -108,6 +108,25 @@ DEFAULT_FILTER_ATTRS = [
 ]
 
 
+RESOURCE_TYPES = ["Cpus", "Memory", "Disk", "Gpus"]
+FLOORED_RESOURCE_FIELD = "FlooredRequest{resource}"
+FLOORED_RESOURCE_SCRIPT = """
+if (
+    doc.containsKey("{resource}Provisioned") &&
+    doc["{resource}Provisioned"].size() > 0 &&
+    doc.containsKey("Request{resource}") &&
+    doc["Request{resource}"].size() > 0 &&
+    doc["{resource}Provisioned"].value < doc["Request{resource}"].value
+    ) {{
+        emit(doc["{resource}Provisioned"].value);
+}} else if (
+    doc.containsKey("Request{resource}") &&
+    doc["Request{resource}"].size() > 0) {{
+        emit(doc["Request{resource}"].value);
+}}
+"""
+
+
 # INSTITUTION_DB = get_institution_database()
 # RESOURCE_DATA = get_topology_resource_data()
 
@@ -259,6 +278,19 @@ class OsgScheddResourcesFilter(BaseFilter):
                 }
             }
         }
+        # Add floored resource requests (INF-3590)
+        fields = []
+        runtime_mappings = {}
+        for resource in RESOURCE_TYPES:
+            fields.append(FLOORED_RESOURCE_FIELD.format(resource=resource))
+            runtime_mappings[FLOORED_RESOURCE_FIELD.format(resource=resource)] = {
+                "type": "long",
+                "script": {
+                    "source": FLOORED_RESOURCE_SCRIPT.format(resource=resource)
+                }
+            }
+        query["fields"] = fields
+        query["runtime_mappings"] = runtime_mappings
         return query
 
 

--- a/accounting/filters/OsgScheddResourcesFilter.py
+++ b/accounting/filters/OsgScheddResourcesFilter.py
@@ -447,7 +447,7 @@ class OsgScheddResourcesFilter(BaseFilter):
                     memory_increase_factor = target_memory / request_memory
                 else:
                     increased_memory = True
-            except (ValueError, AttributeError,):
+            except (ValueError, AttributeError, TypeError,):
                 increased_memory = possible_vacates_due_to_resources > 0
 
         o["_NumJobsCanBumpRequestMemory"].append(int(can_increase_memory))

--- a/accounting/filters/PathScheddCpuFilter.py
+++ b/accounting/filters/PathScheddCpuFilter.py
@@ -114,6 +114,9 @@ class PathScheddCpuFilter(BaseFilter):
         # Get input dict
         i = doc["_source"]
 
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
+
         # Get output dict for this project
         project = i.get("ProjectName", i.get("projectname", "UNKNOWN")) or "UNKNOWN"
         o = data["Projects"][project]
@@ -162,6 +165,8 @@ class PathScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -169,6 +174,9 @@ class PathScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this schedd
         schedd = i.get("ScheddName", "UNKNOWN") or "UNKNOWN"
@@ -217,6 +225,8 @@ class PathScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 
@@ -224,6 +234,9 @@ class PathScheddCpuFilter(BaseFilter):
 
         # Get input dict
         i = doc["_source"]
+
+        # Get computed fields (as single values instead of arrays)
+        f = {k: v[0] for k, v in doc.get("fields", {}).items()}
 
         # Get output dict for this user
         user = i.get("User", "UNKNOWN") or "UNKNOWN"
@@ -276,6 +289,8 @@ class PathScheddCpuFilter(BaseFilter):
                     o[attr].append(int(float(i.get(attr))))
                 except TypeError:
                     o[attr].append(None)
+            elif attr.startswith("Request"):
+                o[attr].append(f.get(f"Floored{attr}", i.get(attr, None)))
             else:
                 o[attr].append(i.get(attr, None))
 


### PR DESCRIPTION
We recently had a user use `condor_qedit` to set their `RequestCpus` to a large value after the job had accumulated significant runtime, thus when computing CPU hours, the standard `RequestCpus * RemoteWallClockTime` calculation resulted in a ridiculously large value (in the billions of CPU hours). In the long run, we should solve this by looking at epoch ads instead of history ads.

For now, my proposed workaround is to use `min(RequestCpus, CpusProvisioned)` (and to do the same for other resources). The reason this should work is that the negotiator should always hand out slots that have _at least_ the requested amount. However, we don't want to use the provisioned resources as a rule because slots can be over-provisioned, and it's unlikely that jobs will use the extra provisioned resources.

That does mean there is a potential scenario where we still overestimate usage, which is the case where a user edits their requested resources (after the job starts running) _and_ happen to land on an overprovisioned slot. But this should be rare... even rare than users editing their jobs during/after running.